### PR TITLE
Fix POSSIBLE_FORMATS hint support

### DIFF
--- a/src/core/MultiFormatReader.ts
+++ b/src/core/MultiFormatReader.ts
@@ -124,19 +124,19 @@ export default class MultiFormatReader implements Reader {
             if (addOneDReader && !tryHarder) {
                readers.push(new MultiFormatOneDReader(hints));
             }
-            if (formats.indexOf(BarcodeFormat.QR_CODE) >= 0) {
+            if (formats.includes(BarcodeFormat.QR_CODE)) {
                 readers.push(new QRCodeReader());
             }
-            if (formats.indexOf(BarcodeFormat.DATA_MATRIX) >= 0) {
+            if (formats.includes(BarcodeFormat.DATA_MATRIX)) {
               readers.push(new DataMatrixReader());
             }
-            // if (formats.indexOf(BarcodeFormat.AZTEC) >= 0) {
+            // if (formats.includes(BarcodeFormat.AZTEC)) {
             //   readers.push(new AztecReader())
             // }
-            // if (formats.indexOf(BarcodeFormat.PDF_417) >= 0) {
+            // if (formats.includes(BarcodeFormat.PDF_417)) {
             //    readers.push(new PDF417Reader())
             // }
-            // if (formats.indexOf(BarcodeFormat.MAXICODE) >= 0) {
+            // if (formats.includes(BarcodeFormat.MAXICODE)) {
             //    readers.push(new MaxiCodeReader())
             // }
             // At end in "try harder" mode

--- a/src/core/MultiFormatReader.ts
+++ b/src/core/MultiFormatReader.ts
@@ -101,21 +101,22 @@ export default class MultiFormatReader implements Reader {
 
         const tryHarder: boolean = hints !== null && hints !== undefined && undefined !== hints.get(DecodeHintType.TRY_HARDER);
         /*@SuppressWarnings("unchecked")*/
-        const formats = hints === null || hints === undefined ? null : hints.get(DecodeHintType.POSSIBLE_FORMATS);
+        const formats = hints === null || hints === undefined ? null : <BarcodeFormat[]>hints.get(DecodeHintType.POSSIBLE_FORMATS);
         const readers = new Array<Reader>();
         if (formats !== null && formats !== undefined) {
-            const addOneDReader: boolean =
-                formats.contains(BarcodeFormat.UPC_A) ||
-                formats.contains(BarcodeFormat.UPC_E) ||
-                formats.contains(BarcodeFormat.EAN_13) ||
-                formats.contains(BarcodeFormat.EAN_8) ||
-                formats.contains(BarcodeFormat.CODABAR) ||
-                formats.contains(BarcodeFormat.CODE_39) ||
-                formats.contains(BarcodeFormat.CODE_93) ||
-                formats.contains(BarcodeFormat.CODE_128) ||
-                formats.contains(BarcodeFormat.ITF) ||
-                formats.contains(BarcodeFormat.RSS_14) ||
-                formats.contains(BarcodeFormat.RSS_EXPANDED);
+            const addOneDReader: boolean = formats.some(f =>
+                f === BarcodeFormat.UPC_A ||
+                f === BarcodeFormat.UPC_E ||
+                f === BarcodeFormat.EAN_13 ||
+                f === BarcodeFormat.EAN_8 ||
+                f === BarcodeFormat.CODABAR ||
+                f === BarcodeFormat.CODE_39 ||
+                f === BarcodeFormat.CODE_93 ||
+                f === BarcodeFormat.CODE_128 ||
+                f === BarcodeFormat.ITF ||
+                f === BarcodeFormat.RSS_14 ||
+                f === BarcodeFormat.RSS_EXPANDED
+            );
             // Put 1D readers upfront in "normal" mode
 
             // TYPESCRIPTPORT: TODO: uncomment below as they are ported
@@ -123,19 +124,19 @@ export default class MultiFormatReader implements Reader {
             if (addOneDReader && !tryHarder) {
                readers.push(new MultiFormatOneDReader(hints));
             }
-            if (formats.contains(BarcodeFormat.QR_CODE)) {
+            if (formats.indexOf(BarcodeFormat.QR_CODE) >= 0) {
                 readers.push(new QRCodeReader());
             }
-            if (formats.contains(BarcodeFormat.DATA_MATRIX)) {
+            if (formats.indexOf(BarcodeFormat.DATA_MATRIX) >= 0) {
               readers.push(new DataMatrixReader());
             }
-            // if (formats.contains(BarcodeFormat.AZTEC)) {
+            // if (formats.indexOf(BarcodeFormat.AZTEC) >= 0) {
             //   readers.push(new AztecReader())
             // }
-            // if (formats.contains(BarcodeFormat.PDF_417)) {
+            // if (formats.indexOf(BarcodeFormat.PDF_417) >= 0) {
             //    readers.push(new PDF417Reader())
             // }
-            // if (formats.contains(BarcodeFormat.MAXICODE)) {
+            // if (formats.indexOf(BarcodeFormat.MAXICODE) >= 0) {
             //    readers.push(new MaxiCodeReader())
             // }
             // At end in "try harder" mode

--- a/src/core/oned/MultiFormatOneDReader.ts
+++ b/src/core/oned/MultiFormatOneDReader.ts
@@ -41,34 +41,34 @@ export default class MultiFormatOneDReader extends OneDReader {
         const useCode39CheckDigit = hints && hints.get(DecodeHintType.ASSUME_CODE_39_CHECK_DIGIT) !== undefined;
 
         if (possibleFormats) {
-            if (possibleFormats.indexOf(BarcodeFormat.EAN_13) >= 0) {
+            if (possibleFormats.includes(BarcodeFormat.EAN_13)) {
                 this.readers.push(new MultiFormatUPCEANReader(hints));
             }
-            // if (possibleFormats.indexOf(BarcodeFormat.EAN_13) >= 0 ||
-            //     possibleFormats.indexOf(BarcodeFormat.UPC_A) >= 0  ||
-            //     possibleFormats.indexOf(BarcodeFormat.EAN_8) >= 0  ||
-            //     possibleFormats.indexOf(BarcodeFormat.UPC_E)) >= 0 {
+            // if (possibleFormats.includes(BarcodeFormat.EAN_13) ||
+            //     possibleFormats.includes(BarcodeFormat.UPC_A) ||
+            //     possibleFormats.includes(BarcodeFormat.EAN_8) ||
+            //     possibleFormats.includes(BarcodeFormat.UPC_E)) {
             //   readers.push(new MultiFormatUPCEANReader(hints));
             // }
-            if (possibleFormats.indexOf(BarcodeFormat.CODE_39) >= 0) {
+            if (possibleFormats.includes(BarcodeFormat.CODE_39)) {
                this.readers.push(new Code39Reader(useCode39CheckDigit));
             }
-            // if (possibleFormats.indexOf(BarcodeFormat.CODE_93) >= 0) {
+            // if (possibleFormats.includes(BarcodeFormat.CODE_93)) {
             //    this.readers.push(new Code93Reader());
             // }
-            if (possibleFormats.indexOf(BarcodeFormat.CODE_128) >= 0) {
+            if (possibleFormats.includes(BarcodeFormat.CODE_128)) {
                 this.readers.push(new Code128Reader());
             }
-            if (possibleFormats.indexOf(BarcodeFormat.ITF) >= 0) {
+            if (possibleFormats.includes(BarcodeFormat.ITF)) {
                this.readers.push(new ITFReader());
             }
-            // if (possibleFormats.indexOf(BarcodeFormat.CODABAR) >= 0) {
+            // if (possibleFormats.includes(BarcodeFormat.CODABAR)) {
             //    this.readers.push(new CodaBarReader());
             // }
-            // if (possibleFormats.indexOf(BarcodeFormat.RSS_14) >= 0) {
+            // if (possibleFormats.includes(BarcodeFormat.RSS_14)) {
             //    this.readers.push(new RSS14Reader());
             // }
-            // if (possibleFormats.indexOf(BarcodeFormat.RSS_EXPANDED) >= 0) {
+            // if (possibleFormats.includes(BarcodeFormat.RSS_EXPANDED)) {
             //   this.readers.push(new RSSExpandedReader());
             // }
         }

--- a/src/core/oned/MultiFormatOneDReader.ts
+++ b/src/core/oned/MultiFormatOneDReader.ts
@@ -37,38 +37,38 @@ export default class MultiFormatOneDReader extends OneDReader {
 
     public constructor(hints: Map<DecodeHintType, any>) {
         super();
-        const possibleFormats = !hints ? null : hints.get(DecodeHintType.POSSIBLE_FORMATS);
+        const possibleFormats = !hints ? null : <BarcodeFormat[]>hints.get(DecodeHintType.POSSIBLE_FORMATS);
         const useCode39CheckDigit = hints && hints.get(DecodeHintType.ASSUME_CODE_39_CHECK_DIGIT) !== undefined;
 
         if (possibleFormats) {
-            if (possibleFormats.get(BarcodeFormat.EAN_13)) {
+            if (possibleFormats.indexOf(BarcodeFormat.EAN_13) >= 0) {
                 this.readers.push(new MultiFormatUPCEANReader(hints));
             }
-            // if (possibleFormats.get(BarcodeFormat.EAN_13) ||
-            //     possibleFormats.get(BarcodeFormat.UPC_A)  ||
-            //     possibleFormats.get(BarcodeFormat.EAN_8)  ||
-            //     possibleFormats.get(BarcodeFormat.UPC_E)) {
+            // if (possibleFormats.indexOf(BarcodeFormat.EAN_13) >= 0 ||
+            //     possibleFormats.indexOf(BarcodeFormat.UPC_A) >= 0  ||
+            //     possibleFormats.indexOf(BarcodeFormat.EAN_8) >= 0  ||
+            //     possibleFormats.indexOf(BarcodeFormat.UPC_E)) >= 0 {
             //   readers.push(new MultiFormatUPCEANReader(hints));
             // }
-            if (possibleFormats.get(BarcodeFormat.CODE_39)) {
+            if (possibleFormats.indexOf(BarcodeFormat.CODE_39) >= 0) {
                this.readers.push(new Code39Reader(useCode39CheckDigit));
             }
-            // if (possibleFormats.get(BarcodeFormat.CODE_93)) {
+            // if (possibleFormats.indexOf(BarcodeFormat.CODE_93) >= 0) {
             //    this.readers.push(new Code93Reader());
             // }
-            if (possibleFormats.get(BarcodeFormat.CODE_128)) {
+            if (possibleFormats.indexOf(BarcodeFormat.CODE_128) >= 0) {
                 this.readers.push(new Code128Reader());
             }
-            if (possibleFormats.get(BarcodeFormat.ITF)) {
+            if (possibleFormats.indexOf(BarcodeFormat.ITF) >= 0) {
                this.readers.push(new ITFReader());
             }
-            // if (possibleFormats.get(BarcodeFormat.CODABAR)) {
+            // if (possibleFormats.indexOf(BarcodeFormat.CODABAR) >= 0) {
             //    this.readers.push(new CodaBarReader());
             // }
-            // if (possibleFormats.get(BarcodeFormat.RSS_14)) {
+            // if (possibleFormats.indexOf(BarcodeFormat.RSS_14) >= 0) {
             //    this.readers.push(new RSS14Reader());
             // }
-            // if (possibleFormats.get(BarcodeFormat.RSS_EXPANDED)) {
+            // if (possibleFormats.indexOf(BarcodeFormat.RSS_EXPANDED) >= 0) {
             //   this.readers.push(new RSSExpandedReader());
             // }
         }

--- a/src/core/oned/MultiFormatUPCEANReader.ts
+++ b/src/core/oned/MultiFormatUPCEANReader.ts
@@ -36,7 +36,7 @@ export default class MultiFormatUPCEANReader extends OneDReader {
 
     public constructor(hints?: Map<DecodeHintType, any>) {
         super();
-        let possibleFormats = hints == null ? null : hints.get(DecodeHintType.POSSIBLE_FORMATS);
+        let possibleFormats = hints == null ? null : <BarcodeFormat[]>hints.get(DecodeHintType.POSSIBLE_FORMATS);
         let readers: UPCEANReader[] = [];
         if (possibleFormats != null) {
             if (possibleFormats.indexOf(BarcodeFormat.EAN_13) > -1) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
         "lib": [
             "es5",
             "es6",
+            "es7",
             "dom"
         ],
         "outDir": "./esm5/",


### PR DESCRIPTION
**This PR is based on PR #58.** The only real changes in this PR are in the commit da876827d3ea707dc60712e9b0eb3794f64f5020.

It fixes evaluation of the possible barcode formats, passed in via hints. 