### PR TITLE
Replace text-encoding by Node Buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,16 +69,12 @@
     "dependencies": {
         "ts-custom-error": "^2.2.1"
     },
-    "optionalDependencies": {
-        "text-encoding": "^0.6.4"
-    },
     "devDependencies": {
         "@types/chai": "^4.1.2",
         "@types/mocha": "^2.2.48",
         "@types/node": "^8.10.15",
         "@types/seedrandom": "^2.4.27",
         "@types/sharp": "^0.17.8",
-        "@types/text-encoding": "0.0.33",
         "awesome-typescript-loader": "^3.1.3",
         "chai": "^4.1.2",
         "codacy-coverage": "^3.0.0",

--- a/src/core/util/StringEncoding.ts
+++ b/src/core/util/StringEncoding.ts
@@ -1,4 +1,3 @@
-import { TextEncoder as TextEncoderLegacy, TextDecoder as TextDecoderLegacy } from 'text-encoding';
 import CharacterSetECI from './../common/CharacterSetECI';
 import UnsupportedOperationException from '../UnsupportedOperationException';
 
@@ -14,9 +13,9 @@ export default class StringEncoding {
 
         const encodingName = this.encodingName(encoding);
 
-        // Node.js environment fallback.
+        // Node.js environment
         if (!StringEncoding.isBrowser()) {
-            return new TextDecoderLegacy(encodingName).decode(bytes);
+            return Buffer.from(bytes.buffer).toString(encodingName);
         }
 
         // TextDecoder not available
@@ -34,10 +33,10 @@ export default class StringEncoding {
      */
     public static encode(s: string, encoding: string | CharacterSetECI): Uint8Array {
 
-
-        // Uses `text-encoding` package.
+        // Uses Buffer to construct a Uint8Array.
+        // A Buffer in Node is already an instance of Uint8Array.
         if (!StringEncoding.isBrowser()) {
-            return new TextEncoderLegacy(this.encodingName(encoding), { NONSTANDARD_allowLegacyEncoding: true }).encode(s);
+            return Buffer.from(s, this.encodingName(encoding));
         }
 
         // TextEncoder only encodes to UTF8 by default as specified by encoding.spec.whatwg.org

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,10 +114,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/text-encoding@0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@types/text-encoding/-/text-encoding-0.0.33.tgz#67618d2da2cb6055c16c7caa2e967c1c6d1e7600"
-
 "@webassemblyjs/ast@1.5.12":
   version "1.5.12"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.5.12.tgz#a9acbcb3f25333c4edfa1fdf3186b1ccf64e6664"


### PR DESCRIPTION
Resolves #68 

### Changes
- Removed the `text-encoding` dependency.
- Uses [Buffer](https://nodejs.org/api/buffer.html) to encode/decode.

