### PR TITLE
tsc: preserveConstEnums

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
         "alwaysStrict": true,
         "noImplicitAny": false,
         "sourceMap": true,
-        "declaration": true
+        "declaration": true,
+        "preserveConstEnums": true
     },
     "include": [
         "src/**/*.ts"


### PR DESCRIPTION
So that DecodeHintType are available from JS.

https://basarat.gitbooks.io/typescript/docs/enums.html#const-enums