### PR TITLE
ci: test Node.js 8, 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ node_js:
   - 'node'
   - '10'
   - '8'
-  - '6'
 
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,11 @@ env:
 
 language: node_js
 
-node_js: stable
+node_js:
+  - 'node'
+  - '10'
+  - '8'
+  - '6'
 
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test


### PR DESCRIPTION
We should test all current LTS branches to make sure that these work.