### PR TITLE
ci: use yarn cache and cache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ before_script:
 script:
   - yarn cover
 
+cache:
+  yarn: true
+  directories:
+    - node_modules
+
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
   - cat ./coverage/lcov.info | ./node_modules/.bin/codacy-coverage


### PR DESCRIPTION
Cache node_modules and use the Yarn cache to speed up builds / jobs.