### PR TITLE
improve naming and documentation of ReedSolomon encode function

### DIFF
--- a/src/core/common/reedsolomon/ReedSolomonEncoder.ts
+++ b/src/core/common/reedsolomon/ReedSolomonEncoder.ts
@@ -63,11 +63,12 @@ export default class ReedSolomonEncoder {
      * data is stored or transmitted.</p>
      *
      * @param encodingBlock array used for both and output. Caller initializs the array with
-     * the code words (symbols) to be encoded followed by empty elements to be used
-     * to store the error-correction code words.
-     * @param numberOfEcCodeWords the number of elements reserved to store code words
-     * in the array passed as the first parameter. The number of code words (symbols)
-     * to encode is thus encodingBlock.length - numberOfEcCodeWords.
+     * the code words (symbols) to be encoded followed by empty elements allocated to make
+     * space for error-correction code words in the encoded output. The array contains
+     * the encdoded output when encode returns.
+     * @param numberOfEcCodeWords the number of elements reserved in the array (first parameter)
+     * to store error-correction code words. Thus, the number of code words (symbols)
+     * to encode in the first parameter is thus encodingBlock.length - numberOfEcCodeWords.
      * @throws IllegalArgumentException if there are
      */
     public encode(encodingBlock: Int32Array, numberOfEcCodeWords: number /*int*/): void {


### PR DESCRIPTION
Issues address by these proposed changes to ReedSolomonEncoder.encode:

*1*
There was no documentation of what the function does or what its parameters should contain, which was unfortunate since the parameters structure doesn't follow typical conventions. (The first parameter is used for both input and output and contains space reserved only for output.)

*2*
The parameter names are misleading.  The function supports symbol sizes other than 8-bit bytes, yet the second parameter (ecBytes) implies otherwise and does not, in fact, contain the error correct bytes (it's only the count of them).

*3*
The parameter that was named ecBytes must contain a positive integer, yet the validator only checks that its value is non-zero. 

The three issues addressed are also present in the original Java code.  Java uses signed ints for ecBytes, which must be a positive number, but the original validator in the Java code checks only that the input is non-zero.  If the code is being ported to languages that have non-type-safe arrays, this could result in a buffer vulnerability.

My apologies for submitting the PR to to the TypeScript implementation project and not the Java code from which it's ported. I use typescript daily and know how to reliably refactor it with VSCode, but I haven't written Java in many years. Also, while there may be other Reed Solomon implementations in Java, the JavaScript Reed Solomon implementation in this package is by itself a huge asset to the JavaScript community, and improving the documentation would help anyone who needs access to a TypeScript/JavaScript Reed Solomon implementation.
 