### PR TITLE
drawImage bugfix

### DIFF
--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -438,8 +438,9 @@ export class BrowserCodeReader {
      */
     public reset() {
 
+        clearTimeout(this.timeoutHandler);
+        
         // stops the camera, preview and scan 🔴
-        window.clearTimeout(this.timeoutHandler);
         this.stopStreams();
 
         if (undefined !== this.videoPlayEndedEventListener && undefined !== this.videoElement) {

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -439,7 +439,7 @@ export class BrowserCodeReader {
     public reset() {
 
         // stops the camera, preview and scan 🔴
-
+        window.clearTimeout(this.timeoutHandler);
         this.stopStreams();
 
         if (undefined !== this.videoPlayEndedEventListener && undefined !== this.videoElement) {

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -438,7 +438,7 @@ export class BrowserCodeReader {
      */
     public reset() {
 
-        clearTimeout(this.timeoutHandler);
+        window.clearTimeout(this.timeoutHandler);
         
         // stops the camera, preview and scan 🔴
         this.stopStreams();


### PR DESCRIPTION
Fixes:

```
TypeError: Failed to execute 'drawImage' on 'CanvasRenderingContext2D': The provided value is not of type '(CSSImageValue or HTMLImageElement or SVGImageElement or HTMLVideoElement or HTMLCanvasElement or ImageBitmap or OffscreenCanvas)'
    at BrowserBarcodeReader.BrowserCodeReader.drawImageOnCanvas (BrowserCodeReader.js:364)
    at BrowserBarcodeReader.BrowserCodeReader.createBinaryBitmap (BrowserCodeReader.js:353)
    at BrowserBarcodeReader.BrowserCodeReader.decode (BrowserCodeReader.js:338)
    at BrowserBarcodeReader.BrowserCodeReader.decodeOnce (BrowserCodeReader.js:317)
```

which causes a memory leak.