### PR TITLE
Update version of `ts-custom-error` to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "webpack": "./node_modules/.bin/webpack-cli"
     },
     "dependencies": {
-        "ts-custom-error": "^2.2.2"
+        "ts-custom-error": "^3.0.0"
     },
     "optionalDependencies": {
         "text-encoding": "^0.7.0"


### PR DESCRIPTION
The only change between `2.2.2` and `3.0.0` versions of `ts-custom-error` library is the license.
It used to be `WTFPL` License while it has updated to `MIT` in latest `3.0.0` version.

(GH-26) Proposing to update the version in dependencies.