### PR TITLE
Fixes TypeError: Failed to execute 'createObjectURL' on 'URL': No function was found that matched the signature provided.

### DIFF
--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -152,10 +152,10 @@ export class BrowserCodeReader {
      * @todo Return Promise<Result>
      */
     protected startDecodeFromStream(stream: MediaStream, callbackFn?: (...args: any[]) => any): void {
-        if (!this.videoElement && stream.active) {
+        this.stream = stream;
+        if (!this.videoElement && this.stream.active) {
             return this.reset();
         }
-        this.stream = stream;
         this.bindVideoSrc(this.videoElement, stream);
         this.bindEvents(this.videoElement, callbackFn);
     }

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -152,6 +152,9 @@ export class BrowserCodeReader {
      * @todo Return Promise<Result>
      */
     protected startDecodeFromStream(stream: MediaStream, callbackFn?: (...args: any[]) => any): void {
+        if (!this.videoElement && stream.active) {
+            return this.reset();
+        }
         this.stream = stream;
         this.bindVideoSrc(this.videoElement, stream);
         this.bindEvents(this.videoElement, callbackFn);


### PR DESCRIPTION
```js
TypeError: Failed to execute 'createObjectURL' on 'URL': No function was found that matched the signature provided.
    at BrowserBarcodeReader.push../node_modules/@zxing/library/esm5/browser/BrowserCodeReader.js.BrowserCodeReader.bindVideoSrc (BrowserCodeReader.js:373)
    at BrowserBarcodeReader.push../node_modules/@zxing/library/esm5/browser/BrowserCodeReader.js.BrowserCodeReader.startDecodeFromStream (BrowserCodeReader.js:103)
    at BrowserCodeReader.js:86
```

This crash can be triggered by quickly creating and disposing a BrowserCodeReader and repeating that. Due to the various async steps such as Promises and timers, the state of the world can already be different by the time this method runs, but the code assumes all (DOM) references are still available. With async code, this assumption can never be guaranteed: `this.videoElement` can already be `undefined` (gone). Weirdly, the stream is still `active: true` at this time, so we need to clean this up.