### PR TITLE
v0.14.0 - Mind your manners

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,28 @@ or
 
 ### Use on browser with ES6 modules:
 
-```javascript
+```html
 <script type="module">
-    import { BrowserQRCodeReader } from '@zxing/library';
+  import { BrowserQRCodeReader } from '@zxing/library';
+
+  const codeReader = new BrowserQRCodeReader();
+  const img = document.getElementById('img');
+
+  try {
+      const result = await codeReader.decodeFromImage(img);
+  } catch (err) {
+      console.error(err);
+  }
+
+  console.log(result);
+</script>
+```
+
+#### Or asynchronously:
+
+```html
+<script type="module">
+  import('@zxing/library').then({ BrowserQRCodeReader } => {
 
     const codeReader = new BrowserQRCodeReader();
     const img = document.getElementById('img');
@@ -74,26 +93,28 @@ or
     }
 
     console.log(result);
+
+  });
 </script>
 ```
 
 ### Use on browser with AMD:
 
-```javascript
+```html
 <script type="text/javascript" src="https://unpkg.com/requirejs"></script>
 <script type="text/javascript">
-    require(['@zxing/library'], ZXing => {
-        const codeReader = new ZXing.BrowserQRCodeReader();
-        const img = document.getElementById('img');
+  require(['@zxing/library'], ZXing => {
+    const codeReader = new ZXing.BrowserQRCodeReader();
+    const img = document.getElementById('img');
 
-        try {
-            const result = await codeReader.decodeFromImage(img);
-        } catch (err) {
-            console.error(err);
-        }
+    try {
+        const result = await codeReader.decodeFromImage(img);
+    } catch (err) {
+        console.error(err);
+    }
 
-        console.log(result);
-    });
+    console.log(result);
+  });
 </script>
 ```
 
@@ -102,18 +123,18 @@ or
 ```html
 <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
 <script type="text/javascript">
-    window.addEventListener('load', () => {
-        const codeReader = new ZXing.BrowserQRCodeReader();
-        const img = document.getElementById('img');
+  window.addEventListener('load', () => {
+    const codeReader = new ZXing.BrowserQRCodeReader();
+    const img = document.getElementById('img');
 
-        try {
-            const result = await codeReader.decodeFromImage(img);
-        } catch (err) {
-            console.error(err);
-        }
+    try {
+        const result = await codeReader.decodeFromImage(img);
+    } catch (err) {
+        console.error(err);
+    }
 
-        console.log(result);
-    });
+    console.log(result);
+  });
 </script>
 ```
 
@@ -153,10 +174,10 @@ To display the input from the video camera you will need to add a video element 
 
 ```html
 <video
-    id="video"
-    width="300"
-    height="200"
-    style="border: 1px solid gray"
+  id="video"
+  width="300"
+  height="200"
+  style="border: 1px solid gray"
 ></video>
 ```
 
@@ -166,24 +187,24 @@ To start decoding, first obtain a list of video input devices with:
 const codeReader = new ZXing.BrowserQRCodeReader();
 
 codeReader
-    .getVideoInputDevices()
-    .then(videoInputDevices => {
-        videoInputDevices.forEach(device =>
-            console.log(`${device.label}, ${device.deviceId}`)
-        );
-    })
-    .catch(err => console.error(err));
+  .listVideoInputDevices()
+  .then(videoInputDevices => {
+    videoInputDevices.forEach(device =>
+      console.log(`${device.label}, ${device.deviceId}`)
+    );
+  })
+  .catch(err => console.error(err));
 ```
 
-If there is just one input device you can use the first deviceId and the video element id (in the example below is also 'video') to decode:
+If there is just one input device you can use the first `deviceId` and the video element id (in the example below is also 'video') to decode:
 
 ```javascript
 const firstDeviceId = videoInputDevices[0].deviceId;
 
 codeReader
-    .decodeFromInputVideoDevice(firstDeviceId, 'video')
-    .then(result => console.log(result.text))
-    .catch(err => console.error(err));
+  .decodeFromInputVideoDevice(firstDeviceId, 'video')
+  .then(result => console.log(result.text))
+  .catch(err => console.error(err));
 ```
 
 If there are more input devices then you will need to chose one for `codeReader.decodeFromInputVideoDevice` device id parameter.
@@ -192,9 +213,9 @@ You can also provide `undefined` for the device id parameter in which case the l
 
 ```javascript
 codeReader
-    .decodeFromInputVideoDevice(undefined, 'video')
-    .then(result => console.log(result.text))
-    .catch(err => console.error(err));
+  .decodeFromInputVideoDevice(undefined, 'video')
+  .then(result => console.log(result.text))
+  .catch(err => console.error(err));
 ```
 
 ### Scanning from Video File
@@ -203,10 +224,10 @@ Similar as above you can use a video element in the HTML page:
 
 ```html
 <video
-    id="video"
-    width="300"
-    height="200"
-    style="border: 1px solid gray"
+  id="video"
+  width="300"
+  height="200"
+  style="border: 1px solid gray"
 ></video>
 ```
 
@@ -217,18 +238,25 @@ const codeReader = new ZXing.BrowserQRCodeReader();
 const videoSrc = 'your url to a video';
 
 codeReader
-    .decodeFromVideoSource(videoSrc, 'video')
-    .then(result => console.log(result.text))
-    .catch(err => console.error(err));
+  .decodeFromVideo('video', videoSrc)
+  .then(result => console.log(result.text))
+  .catch(err => console.error(err));
 ```
 
 You can also decode the video url without showing it in the page, in this case no `video` element is needed in HTML.
 
 ```javascript
 codeReader
-    .decodeFromVideoSource(videoSrc)
-    .then(result => console.log(result.text))
-    .catch(err => console.error(err));
+  .decodeFromVideoUrl(videoUrl)
+  .then(result => console.log(result.text))
+  .catch(err => console.error(err));
+
+// or alternatively
+
+codeReader
+  .decodeFromVideo(null, videoUrl)
+  .then(result => console.log(result.text))
+  .catch(err => console.error(err));
 ```
 
 ### Scanning from Image
@@ -237,11 +265,11 @@ Similar as above you can use a img element in the HTML page (with src attribute 
 
 ```html
 <img
-    id="img"
-    src="qrcode-image.png"
-    width="200"
-    height="300"
-    style="border: 1px solid gray"
+  id="img"
+  src="qrcode-image.png"
+  width="200"
+  height="300"
+  style="border: 1px solid gray"
 />
 ```
 
@@ -252,9 +280,9 @@ const codeReader = new ZXing.BrowserQRCodeReader();
 const img = document.getElementById('img');
 
 codeReader
-    .decodeFromImage(img)
-    .then(result => console.log(result.text))
-    .catch(err => console.error(err));
+  .decodeFromImage(img)
+  .then(result => console.log(result.text))
+  .catch(err => console.error(err));
 ```
 
 You can also decode the image url without showing it in the page, in this case no `img` element is needed in HTML:
@@ -263,19 +291,19 @@ You can also decode the image url without showing it in the page, in this case n
 const imgSrc = 'url to image';
 
 codeReader
-    .decodeFromImage(undefined, imgSrc)
-    .then(result => console.log(result.text))
-    .catch(err => console.error(err));
+  .decodeFromImage(undefined, imgSrc)
+  .then(result => console.log(result.text))
+  .catch(err => console.error(err));
 ```
 
 Or decode the image url directly from an url, with an `img` element in page (notice no `src` attribute is set for `img` element):
 
 ```html
 <img
-    id="img-to-decode"
-    width="200"
-    height="300"
-    style="border: 1px solid gray"
+  id="img-to-decode"
+  width="200"
+  height="300"
+  style="border: 1px solid gray"
 />
 ```
 
@@ -284,9 +312,9 @@ const imgSrc = 'url to image';
 const imgDomId = 'img-to-decode';
 
 codeReader
-    .decodeFromImage(imgDomId, imgSrc)
-    .then(result => console.log(result.text))
-    .catch(err => console.error(err));
+  .decodeFromImage(imgDomId, imgSrc)
+  .then(result => console.log(result.text))
+  .catch(err => console.error(err));
 ```
 
 ## Barcode generation

--- a/docs/examples/barcode-camera/index.html
+++ b/docs/examples/barcode-camera/index.html
@@ -102,7 +102,6 @@
                     document.getElementById('resetButton').addEventListener('click', () => {
                         document.getElementById('result').textContent = '';
                         codeReader.reset();
-
                         console.log('Reset.')
                     })
 

--- a/docs/examples/multi-camera/index.html
+++ b/docs/examples/multi-camera/index.html
@@ -86,12 +86,15 @@
                     }
 
                     document.getElementById('startButton').addEventListener('click', () => {
-                        codeReader.decodeFromInputVideoDevice(selectedDeviceId, 'video').then((result) => {
+                        codeReader.decodeFromInputVideoDeviceContinuously(selectedDeviceId, 'video', (result, err) => {
+                          if (result) {
                             console.log(result)
                             document.getElementById('result').textContent = result.text
-                        }).catch((err) => {
+                          }
+                          if (err && !(err instanceof ZXing.NotFoundException)) {
                             console.error(err)
                             document.getElementById('result').textContent = err
+                          }
                         })
                         console.log(`Started continous decode from camera with id ${selectedDeviceId}`)
                     })

--- a/docs/examples/multi-camera/index.html
+++ b/docs/examples/multi-camera/index.html
@@ -2,114 +2,121 @@
 <html lang="en">
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="author" content="ZXing for JS">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="author" content="ZXing for JS">
 
-    <title>ZXing TypeScript | Decoding from camera stream</title>
+  <title>ZXing TypeScript | Decoding from camera stream</title>
 
-    <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://unpkg.com/normalize.css@8.0.0/normalize.css">
-    <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://unpkg.com/milligram@1.3.0/dist/milligram.min.css">
+  <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null"
+    href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+  <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null"
+    href="https://unpkg.com/normalize.css@8.0.0/normalize.css">
+  <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null"
+    href="https://unpkg.com/milligram@1.3.0/dist/milligram.min.css">
 </head>
 
 <body>
 
-    <main class="wrapper" style="padding-top:2em">
+  <main class="wrapper" style="padding-top:2em">
 
-        <section class="container" id="demo-content">
-            <h1 class="title">Scan 1D/2D Code from Video Camera</h1>
+    <section class="container" id="demo-content">
+      <h1 class="title">Scan 1D/2D Code from Video Camera</h1>
 
-            <p>
-                <a class="button-small button-outline" href="../../index.html">HOME 🏡</a>
-            </p>
+      <p>
+        <a class="button-small button-outline" href="../../index.html">HOME 🏡</a>
+      </p>
 
-            <p>This example shows how to scan any supported 1D/2D code with ZXing javascript library from the device video camera. If more
-                than one video input devices are available (for example front and back camera) the example shows how to read
-                them and use a select to change the input device.</p>
+      <p>This example shows how to scan any supported 1D/2D code with ZXing javascript library from the device video
+        camera. If more
+        than one video input devices are available (for example front and back camera) the example shows how to read
+        them and use a select to change the input device.</p>
 
-            <div>
-                <a class="button" id="startButton">Start</a>
-                <a class="button" id="resetButton">Reset</a>
-            </div>
+      <div>
+        <a class="button" id="startButton">Start</a>
+        <a class="button" id="resetButton">Reset</a>
+      </div>
 
-            <div>
-                <video id="video" width="300" height="200" style="border: 1px solid gray"></video>
-            </div>
+      <div>
+        <video id="video" width="300" height="200" style="border: 1px solid gray"></video>
+      </div>
 
-            <div id="sourceSelectPanel" style="display:none">
-                <label for="sourceSelect">Change video source:</label>
-                <select id="sourceSelect" style="max-width:400px">
-                </select>
-            </div>
+      <div id="sourceSelectPanel" style="display:none">
+        <label for="sourceSelect">Change video source:</label>
+        <select id="sourceSelect" style="max-width:400px">
+        </select>
+      </div>
 
-            <label>Result:</label>
-            <blockquote>
-                <p id="result"></p>
-            </blockquote>
+      <label>Result:</label>
+      <blockquote>
+        <p id="result"></p>
+      </blockquote>
 
-            <p>See the <a href="https://github.com/zxing-js/library/tree/master/docs/examples/multi-camera/">source code</a> for this example.</p>
-        </section>
+      <p>See the <a href="https://github.com/zxing-js/library/tree/master/docs/examples/multi-camera/">source code</a>
+        for this example.</p>
+    </section>
 
-        <footer class="footer">
-            <section class="container">
-                <p>ZXing TypeScript Demo. Licensed under the <a target="_blank" href="https://github.com/zxing-js/library#license" title="MIT">MIT</a>.</p>
-            </section>
-        </footer>
+    <footer class="footer">
+      <section class="container">
+        <p>ZXing TypeScript Demo. Licensed under the <a target="_blank"
+            href="https://github.com/zxing-js/library#license" title="MIT">MIT</a>.</p>
+      </section>
+    </footer>
 
-    </main>
+  </main>
 
-    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
-    <script type="text/javascript">
-        window.addEventListener('load', function () {
-            let selectedDeviceId;
-            const codeReader = new ZXing.BrowserMultiFormatReader()
-            console.log('ZXing code reader initialized')
-            codeReader.getVideoInputDevices()
-                .then((videoInputDevices) => {
-                    const sourceSelect = document.getElementById('sourceSelect')
-                    selectedDeviceId = videoInputDevices[0].deviceId
-                    if (videoInputDevices.length >= 1) {
-                        videoInputDevices.forEach((element) => {
-                            const sourceOption = document.createElement('option')
-                            sourceOption.text = element.label
-                            sourceOption.value = element.deviceId
-                            sourceSelect.appendChild(sourceOption)
-                        })
+  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+  <script type="text/javascript">
+    window.addEventListener('load', function () {
+      let selectedDeviceId;
+      const codeReader = new ZXing.BrowserMultiFormatReader()
+      console.log('ZXing code reader initialized')
+      codeReader.getVideoInputDevices()
+        .then((videoInputDevices) => {
+          const sourceSelect = document.getElementById('sourceSelect')
+          selectedDeviceId = videoInputDevices[0].deviceId
+          if (videoInputDevices.length >= 1) {
+            videoInputDevices.forEach((element) => {
+              const sourceOption = document.createElement('option')
+              sourceOption.text = element.label
+              sourceOption.value = element.deviceId
+              sourceSelect.appendChild(sourceOption)
+            })
 
-                        sourceSelect.onchange = () => {
-                            selectedDeviceId = sourceSelect.value;
-                        };
+            sourceSelect.onchange = () => {
+              selectedDeviceId = sourceSelect.value;
+            };
 
-                        const sourceSelectPanel = document.getElementById('sourceSelectPanel')
-                        sourceSelectPanel.style.display = 'block'
-                    }
+            const sourceSelectPanel = document.getElementById('sourceSelectPanel')
+            sourceSelectPanel.style.display = 'block'
+          }
 
-                    document.getElementById('startButton').addEventListener('click', () => {
-                        codeReader.decodeFromInputVideoDeviceContinuously(selectedDeviceId, 'video', (result, err) => {
-                          if (result) {
-                            console.log(result)
-                            document.getElementById('result').textContent = result.text
-                          }
-                          if (err && !(err instanceof ZXing.NotFoundException)) {
-                            console.error(err)
-                            document.getElementById('result').textContent = err
-                          }
-                        })
-                        console.log(`Started continous decode from camera with id ${selectedDeviceId}`)
-                    })
+          document.getElementById('startButton').addEventListener('click', () => {
+            codeReader.decodeFromInputVideoDeviceContinuously(selectedDeviceId, 'video', (result, err) => {
+              if (result) {
+                console.log(result)
+                document.getElementById('result').textContent = result.text
+              }
+              if (err && !(err instanceof ZXing.NotFoundException)) {
+                console.error(err)
+                document.getElementById('result').textContent = err
+              }
+            })
+            console.log(`Started continous decode from camera with id ${selectedDeviceId}`)
+          })
 
-                    document.getElementById('resetButton').addEventListener('click', () => {
-                        codeReader.reset()
-                        console.log('Reset.')
-                    })
+          document.getElementById('resetButton').addEventListener('click', () => {
+            codeReader.reset()
+            document.getElementById('result').textContent = '';
+            console.log('Reset.')
+          })
 
-                })
-                .catch((err) => {
-                    console.error(err)
-                })
         })
-    </script>
+        .catch((err) => {
+          console.error(err)
+        })
+    })
+  </script>
 
 </body>
 

--- a/docs/examples/qr-camera/index.html
+++ b/docs/examples/qr-camera/index.html
@@ -2,111 +2,114 @@
 <html lang="en">
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="author" content="ZXing for JS">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="author" content="ZXing for JS">
 
-    <title>ZXing TypeScript | Decoding from camera stream</title>
+  <title>ZXing TypeScript | Decoding from camera stream</title>
 
-    <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://unpkg.com/normalize.css@8.0.0/normalize.css">
-    <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://unpkg.com/milligram@1.3.0/dist/milligram.min.css">
+  <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+  <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://unpkg.com/normalize.css@8.0.0/normalize.css">
+  <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://unpkg.com/milligram@1.3.0/dist/milligram.min.css">
 </head>
 
 <body>
 
-    <main class="wrapper" style="padding-top:2em">
+  <main class="wrapper" style="padding-top:2em">
 
-        <section class="container" id="demo-content">
-            <h1 class="title">Scan QR Code from Video Camera</h1>
+    <section class="container" id="demo-content">
+      <h1 class="title">Scan QR Code from Video Camera</h1>
 
-            <p>
-                <a class="button-small button-outline" href="../../index.html">HOME 🏡</a>
-            </p>
+      <p>
+        <a class="button-small button-outline" href="../../index.html">HOME 🏡</a>
+      </p>
 
-            <p>This example shows how to scan a QR code with ZXing javascript library from the device video camera. If more
-                than one video input devices are available (for example front and back camera) the example shows how to read
-                them and use a select to change the input device.</p>
+      <p>This example shows how to scan a QR code with ZXing javascript library from the device video camera. If more
+        than one video input devices are available (for example front and back camera) the example shows how to read
+        them and use a select to change the input device.</p>
 
-            <div>
-                <a class="button" id="startButton">Start</a>
-                <a class="button" id="resetButton">Reset</a>
-            </div>
+      <div>
+        <a class="button" id="startButton">Start</a>
+        <a class="button" id="resetButton">Reset</a>
+      </div>
 
-            <div>
-                <video id="video" width="300" height="200" style="border: 1px solid gray"></video>
-            </div>
+      <div>
+        <video id="video" width="300" height="200" style="border: 1px solid gray"></video>
+      </div>
 
-            <div id="sourceSelectPanel" style="display:none">
-                <label for="sourceSelect">Change video source:</label>
-                <select id="sourceSelect" style="max-width:400px">
-                </select>
-            </div>
+      <div id="sourceSelectPanel" style="display:none">
+        <label for="sourceSelect">Change video source:</label>
+        <select id="sourceSelect" style="max-width:400px">
+        </select>
+      </div>
 
-            <label>Result:</label>
-            <blockquote>
-                <p id="result"></p>
-            </blockquote>
+      <label>Result:</label>
+      <blockquote>
+        <p id="result"></p>
+      </blockquote>
 
-            <p>See the <a href="https://github.com/zxing-js/library/tree/master/docs/examples/qr-camera/">source code</a> for this example.</p>
-        </section>
+      <p>See the <a href="https://github.com/zxing-js/library/tree/master/docs/examples/qr-camera/">source code</a> for
+        this example.</p>
+    </section>
 
-        <footer class="footer">
-            <section class="container">
-                <p>ZXing TypeScript Demo. Licensed under the <a target="_blank" href="https://github.com/zxing-js/library#license" title="MIT">MIT</a>.</p>
-            </section>
-        </footer>
+    <footer class="footer">
+      <section class="container">
+        <p>ZXing TypeScript Demo. Licensed under the <a target="_blank"
+            href="https://github.com/zxing-js/library#license" title="MIT">MIT</a>.</p>
+      </section>
+    </footer>
 
-    </main>
+  </main>
 
-    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
-    <script type="text/javascript">
-        window.addEventListener('load', function () {
-            let selectedDeviceId;
-            const codeReader = new ZXing.BrowserQRCodeReader()
-            console.log('ZXing code reader initialized')
-            codeReader.getVideoInputDevices()
-                .then((videoInputDevices) => {
-                    const sourceSelect = document.getElementById('sourceSelect')
-                    selectedDeviceId = videoInputDevices[0].deviceId
-                    if (videoInputDevices.length >= 1) {
-                        videoInputDevices.forEach((element) => {
-                            const sourceOption = document.createElement('option')
-                            sourceOption.text = element.label
-                            sourceOption.value = element.deviceId
-                            sourceSelect.appendChild(sourceOption)
-                        })
+  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+  <script type="text/javascript">
+    window.addEventListener('load', function () {
+      let selectedDeviceId;
+      const codeReader = new ZXing.BrowserQRCodeReader()
+      console.log('ZXing code reader initialized')
+      codeReader.getVideoInputDevices()
+        .then((videoInputDevices) => {
+          const sourceSelect = document.getElementById('sourceSelect')
+          selectedDeviceId = videoInputDevices[0].deviceId
+          if (videoInputDevices.length >= 1) {
+            videoInputDevices.forEach((element) => {
+              const sourceOption = document.createElement('option')
+              sourceOption.text = element.label
+              sourceOption.value = element.deviceId
+              sourceSelect.appendChild(sourceOption)
+            })
 
-                        sourceSelect.onchange = () => {
-                            selectedDeviceId = sourceSelect.value;
-                        };
+            sourceSelect.onchange = () => {
+              selectedDeviceId = sourceSelect.value;
+            };
 
-                        const sourceSelectPanel = document.getElementById('sourceSelectPanel')
-                        sourceSelectPanel.style.display = 'block'
-                    }
+            const sourceSelectPanel = document.getElementById('sourceSelectPanel')
+            sourceSelectPanel.style.display = 'block'
+          }
 
-                    document.getElementById('startButton').addEventListener('click', () => {
-                        codeReader.decodeFromInputVideoDevice(selectedDeviceId, 'video').then((result) => {
-                            console.log(result)
-                            document.getElementById('result').textContent = result.text
-                        }).catch((err) => {
-                            console.error(err)
-                            document.getElementById('result').textContent = err
-                        })
-                        console.log(`Started continous decode from camera with id ${selectedDeviceId}`)
-                    })
+          document.getElementById('startButton').addEventListener('click', () => {
+            codeReader.decodeFromInputVideoDevice(selectedDeviceId, 'video').then((result) => {
+              console.log(result)
+              document.getElementById('result').textContent = result.text
+            }).catch((err) => {
+              console.error(err)
+              document.getElementById('result').textContent = err
+            })
+            console.log(`Started continous decode from camera with id ${selectedDeviceId}`)
+          })
 
-                    document.getElementById('resetButton').addEventListener('click', () => {
-                        codeReader.reset()
-                        console.log('Reset.')
-                    })
+          document.getElementById('resetButton').addEventListener('click', () => {
+            codeReader.reset()
+            document.getElementById('result').textContent = '';
+            console.log('Reset.')
+          })
 
-                })
-                .catch((err) => {
-                    console.error(err)
-                })
         })
-    </script>
+        .catch((err) => {
+          console.error(err)
+        })
+    })
+  </script>
 
 </body>
 

--- a/docs/examples/qr-video/index.html
+++ b/docs/examples/qr-video/index.html
@@ -2,83 +2,97 @@
 <html lang="en">
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="author" content="ZXing for JS">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="author" content="ZXing for JS">
 
-    <title>ZXing TypeScript | Decoding from video</title>
+  <title>ZXing TypeScript | Decoding from video</title>
 
-    <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
-    <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://unpkg.com/normalize.css@8.0.0/normalize.css">
-    <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://unpkg.com/milligram@1.3.0/dist/milligram.min.css">
+  <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
+  <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://unpkg.com/normalize.css@8.0.0/normalize.css">
+  <link rel="preload" as="style" onload="this.rel='stylesheet';this.onload=null" href="https://unpkg.com/milligram@1.3.0/dist/milligram.min.css">
 </head>
 
 <body>
 
-    <main class="wrapper" style="padding-top:2em">
+  <main class="wrapper" style="padding-top:2em">
 
-        <section class="container" id="demo-content">
-            <h1 class="title">Scan QR Code from Video File</h1>
+    <section class="container" id="demo-content">
+      <h1 class="title">Scan QR Code from Video File</h1>
 
-            <p>
-                <a class="button-small button-outline" href="../../index.html">HOME 🏡</a>
-            </p>
+      <p>
+        <a class="button-small button-outline" href="../../index.html">HOME 🏡</a>
+      </p>
 
-            <p>This example shows how to scan a QR code with ZXing javascript library from a video file. The example decodes
-                from an url and shows the video while decoding, however is also possbile to decode without showing the video.</p>
+      <p>
+        This example shows how to scan a QR code with ZXing javascript library from a video file. The example decodes
+        from an url and shows the video while decoding, however is also possbile to decode without showing the video.
+      </p>
 
-            <div>
-                <a class="button" id="startButton">Start</a>
-                <a class="button" id="resetButton">Reset</a>
-            </div>
+      <div>
+        <a class="button" id="startButton">Start</a>
+        <a class="button" id="resetButton">Reset</a>
+      </div>
 
-            <small>QR code video from <a href="https://cirocosta.github.io/qcode-decoder/">https://cirocosta.github.io/qcode-decoder/</a>.</small>
-            <div>
-                <video id="video" width="200" height="300" style="border: 1px solid gray" muted="muted"></video>
-            </div>
+      <small>
+        QR code video from
+        <a href="https://cirocosta.github.io/qcode-decoder/">https://cirocosta.github.io/qcode-decoder/</a>.</small>
+      <div>
+        <video id="video" width="200" height="300" style="border: 1px solid gray" muted="muted"></video>
+      </div>
 
-            <label>Result:</label>
-            <blockquote>
-                <p id="result"></p>
-            </blockquote>
+      <label>Result:</label>
+      <blockquote>
+        <p id="result"></p>
+      </blockquote>
 
-            <p>See the <a href="https://github.com/zxing-js/library/tree/master/docs/examples/qr-video/">source code</a> for this example.</p>
+      <p>
+        See the <a href="https://github.com/zxing-js/library/tree/master/docs/examples/qr-video/">source code</a> for
+        this example.
+      </p>
 
-        </section>
+    </section>
 
-        <footer class="footer">
-            <section class="container">
-                <p>ZXing TypeScript Demo. Licensed under the <a target="_blank" href="https://github.com/zxing-js/library#license" title="MIT">MIT</a>.</p>
-            </section>
-        </footer>
+    <footer class="footer">
+      <section class="container">
+        <p>
+          ZXing TypeScript Demo. Licensed under the <a target="_blank"
+            href="https://github.com/zxing-js/library#license" title="MIT">MIT</a>.
+        </p>
+      </section>
+    </footer>
 
-    </main>
+  </main>
 
-    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
-    <script type="text/javascript">
-        window.addEventListener('load', function () {
-            const codeReader = new ZXing.BrowserQRCodeReader()
-            console.log('ZXing code reader initialized')
+  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+  <script type="text/javascript">
+    window.addEventListener('load', function () {
+      const codeReader = new ZXing.BrowserQRCodeReader()
+      console.log('ZXing code reader initialized')
 
-            document.getElementById('startButton').addEventListener('click', () => {
-                const videoSrc = '../../resources/qrcode-video.mp4'
-                codeReader.decodeFromVideoSource(videoSrc, 'video').then((result) => {
-                    console.log(result)
-                    document.getElementById('result').textContent = result.text
-                }).catch((err) => {
-                    console.error(err)
-                    document.getElementById('result').textContent = err
-                })
-                console.log(`Started decode for video from ${videoSrc}`)
-            })
+      const resultContainer = document.getElementById('result')
 
-            document.getElementById('resetButton').addEventListener('click', () => {
-                codeReader.reset()
-                console.log('Reset.')
-            })
+      document.getElementById('startButton').addEventListener('click', async () => {
+        const video = document.getElementById('video')
+        video.setAttribute('src', '../../resources/qrcode-video.mp4')
+        try {
+          const result = await codeReader.decodeFromVideo(video)
+          console.log(result)
+          resultContainer.textContent = result.text
+        } catch (err) {
+          console.error(err)
+          resultContainer.textContent = err
+        }
+      })
 
-        })
-    </script>
+      document.getElementById('resetButton').addEventListener('click', () => {
+        codeReader.reset()
+        resultContainer.textContent = ''
+        console.log('Reset.')
+      })
+
+    })
+  </script>
 
 </body>
 

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -3,16 +3,14 @@ import BinaryBitmap from '../core/BinaryBitmap';
 import ChecksumException from '../core/ChecksumException';
 import HybridBinarizer from '../core/common/HybridBinarizer';
 import DecodeHintType from '../core/DecodeHintType';
-import Exception from '../core/Exception';
 import FormatException from '../core/FormatException';
 import NotFoundException from '../core/NotFoundException';
 import Reader from '../core/Reader';
 import Result from '../core/Result';
+import { ContinuousDecodeCallback } from './ContinuousDecodeCallback';
 import { HTMLCanvasElementLuminanceSource } from './HTMLCanvasElementLuminanceSource';
+import { HTMLVisualMediaElement } from './HTMLVisualMediaElement';
 import { VideoInputDevice } from './VideoInputDevice';
-
-type HTMLVisualMediaElement = HTMLVideoElement | HTMLImageElement;
-type ContinuousDecodeCallback = (result: Result, error?: Exception) => any;
 
 /**
  * @deprecated Moving to @zxing/browser

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -688,7 +688,7 @@ export class BrowserCodeReader {
      *
      * @param videoElement
      */
-    public cleanVideoSource(videoElement: HTMLVideoElement): void {
+    private cleanVideoSource(videoElement: HTMLVideoElement): void {
 
         try {
             videoElement.srcObject = null;

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -292,37 +292,6 @@ export class BrowserCodeReader {
   }
 
   /**
-   * Sets a HTMLVideoElement for scanning or creates a new one.
-   *
-   * @param videoSrc The HTMLVideoElement to be set.
-   */
-  protected prepareVideoElement(videoSrc?: HTMLVideoElement | string): HTMLVideoElement {
-
-    let videoElement: HTMLVideoElement;
-
-    if (!videoSrc && typeof document !== 'undefined') {
-      videoElement = document.createElement('video');
-      videoElement.width = 200;
-      videoElement.height = 200;
-    }
-
-    if (typeof videoSrc === 'string') {
-      videoElement = <HTMLVideoElement>this.getMediaElement(videoSrc, 'video');
-    }
-
-    if (videoSrc instanceof HTMLVideoElement) {
-      videoElement = videoSrc;
-    }
-
-    // Needed for iOS 11
-    videoElement.setAttribute('autoplay', 'true');
-    videoElement.setAttribute('muted', 'true');
-    videoElement.setAttribute('playsinline', 'true');
-
-    return videoElement;
-  }
-
-  /**
    * Searches and validates a media element.
    */
   protected getMediaElement(mediaElementId: string, type: string): HTMLVisualMediaElement {
@@ -513,25 +482,56 @@ export class BrowserCodeReader {
     return true;
   }
 
-  protected prepareImageElement(imageSrc?: HTMLImageElement | string): HTMLImageElement {
+  protected prepareImageElement(imageSource?: HTMLImageElement | string): HTMLImageElement {
 
     let imageElement: HTMLImageElement;
 
-    if (typeof imageSrc === 'undefined') {
+    if (typeof imageSource === 'undefined') {
       imageElement = document.createElement('img');
       imageElement.width = 200;
       imageElement.height = 200;
     }
 
-    if (typeof imageSrc === 'string') {
-      imageElement = <HTMLImageElement>this.getMediaElement(imageSrc, 'img');
+    if (typeof imageSource === 'string') {
+      imageElement = <HTMLImageElement>this.getMediaElement(imageSource, 'img');
     }
 
-    if (imageSrc instanceof HTMLImageElement) {
-      imageElement = imageSrc;
+    if (imageSource instanceof HTMLImageElement) {
+      imageElement = imageSource;
     }
 
     return imageElement;
+  }
+
+  /**
+   * Sets a HTMLVideoElement for scanning or creates a new one.
+   *
+   * @param videoSource The HTMLVideoElement to be set.
+   */
+  protected prepareVideoElement(videoSource?: HTMLVideoElement | string): HTMLVideoElement {
+
+    let videoElement: HTMLVideoElement;
+
+    if (!videoSource && typeof document !== 'undefined') {
+      videoElement = document.createElement('video');
+      videoElement.width = 200;
+      videoElement.height = 200;
+    }
+
+    if (typeof videoSource === 'string') {
+      videoElement = <HTMLVideoElement>this.getMediaElement(videoSource, 'video');
+    }
+
+    if (videoSource instanceof HTMLVideoElement) {
+      videoElement = videoSource;
+    }
+
+    // Needed for iOS 11
+    videoElement.setAttribute('autoplay', 'true');
+    videoElement.setAttribute('muted', 'true');
+    videoElement.setAttribute('playsinline', 'true');
+
+    return videoElement;
   }
 
   /**

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -7,7 +7,7 @@ import FormatException from '../core/FormatException';
 import NotFoundException from '../core/NotFoundException';
 import Reader from '../core/Reader';
 import Result from '../core/Result';
-import { ContinuousDecodeCallback } from './ContinuousDecodeCallback';
+import { DecodeContinuouslyCallback } from './DecodeContinuouslyCallback';
 import { HTMLCanvasElementLuminanceSource } from './HTMLCanvasElementLuminanceSource';
 import { HTMLVisualMediaElement } from './HTMLVisualMediaElement';
 import { VideoInputDevice } from './VideoInputDevice';
@@ -217,7 +217,7 @@ export class BrowserCodeReader {
    *
    * @memberOf BrowserCodeReader
    */
-  public async decodeFromInputVideoDeviceContinuously(deviceId: string | null, videoSource: string | HTMLVideoElement | null, callbackFn: ContinuousDecodeCallback): Promise<void> {
+  public async decodeFromInputVideoDeviceContinuously(deviceId: string | null, videoSource: string | HTMLVideoElement | null, callbackFn: DecodeContinuouslyCallback): Promise<void> {
 
     this.reset();
 
@@ -567,7 +567,7 @@ export class BrowserCodeReader {
   /**
    * Continuously decodes from video input.
    */
-  private decodeContinuously(element: HTMLVideoElement, callbackFn: ContinuousDecodeCallback): void {
+  private decodeContinuously(element: HTMLVideoElement, callbackFn: DecodeContinuouslyCallback): void {
 
     const loop = () => {
 

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -523,7 +523,7 @@ export class BrowserCodeReader {
   /**
    *
    */
-  protected getCaptureCanvasContext(mediaElement?: HTMLMediaElement) {
+  protected getCaptureCanvasContext(mediaElement?: HTMLVisualMediaElement) {
 
     if (!this.captureCanvasContext) {
       const elem = this.getCaptureCanvas(mediaElement);
@@ -537,7 +537,7 @@ export class BrowserCodeReader {
   /**
    *
    */
-  protected getCaptureCanvas(mediaElement?: HTMLMediaElement): HTMLCanvasElement {
+  protected getCaptureCanvas(mediaElement?: HTMLVisualMediaElement): HTMLCanvasElement {
 
     if (!this.captureCanvas) {
       const elem = this.createCaptureCanvas(mediaElement);
@@ -562,12 +562,12 @@ export class BrowserCodeReader {
   }
 
   /**
-     * 🖌 Prepares the canvas for capture and scan frames.
-     */
-  protected createCaptureCanvas(mediaElement?: HTMLMediaElement): HTMLCanvasElement {
+   * 🖌 Prepares the canvas for capture and scan frames.
+   */
+  protected createCaptureCanvas(mediaElement?: HTMLVisualMediaElement): HTMLCanvasElement {
 
-        if (typeof document === 'undefined') {
-            this._destroyCaptureCanvas();
+    if (typeof document === 'undefined') {
+      this._destroyCaptureCanvas();
             return null;
         }
 

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -84,20 +84,34 @@ export class BrowserCodeReader {
     /**
      * Should contain the current registered listener for video playing,
      * used to unregister that listener when needed.
-     */
-    protected videoPlayingEventListener: EventListener;
+   */
+  protected videoPlayingEventListener: EventListener;
 
-    /**
-     * Creates an instance of BrowserCodeReader.
-     * @param {Reader} reader The reader instance to decode the barcode
+  /**
+   * Sets the hints.
+   */
+  set hints(hints: Map<DecodeHintType, any>) {
+    this._hints = hints || null;
+  }
+
+  /**
+   * Sets the hints.
+   */
+  get hints(): Map<DecodeHintType, any> {
+    return this._hints;
+  }
+
+  /**
+   * Creates an instance of BrowserCodeReader.
+   * @param {Reader} reader The reader instance to decode the barcode
      * @param {number} [timeBetweenScansMillis=500] the time delay between subsequent decode tries
-     *
-     * @memberOf BrowserCodeReader
-     */
-    public constructor(protected readonly reader: Reader, protected timeBetweenScansMillis: number = 500, protected hints?: Map<DecodeHintType, any>) { }
+   *
+   * @memberOf BrowserCodeReader
+   */
+  public constructor(protected readonly reader: Reader, protected timeBetweenScansMillis: number = 500, protected _hints?: Map<DecodeHintType, any>) { }
 
-    /**
-     * Lists all the available video input devices.
+  /**
+   * Lists all the available video input devices.
      */
     public async listVideoInputDevices(): Promise<MediaDeviceInfo[]> {
 
@@ -541,13 +555,13 @@ export class BrowserCodeReader {
     }
 
     /**
-     * Call the encapsulated readers decode
-     */
-    protected decodeBitmap(binaryBitmap: BinaryBitmap): Result {
-        return this.reader.decode(binaryBitmap, this.hints);
-    }
+   * Call the encapsulated readers decode
+   */
+  protected decodeBitmap(binaryBitmap: BinaryBitmap): Result {
+    return this.reader.decode(binaryBitmap, this._hints);
+  }
 
-    /**
+  /**
      * 🖌 Prepares the canvas for capture and scan frames.
      */
   protected createCaptureCanvas(mediaElement?: HTMLMediaElement): HTMLCanvasElement {

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -19,71 +19,71 @@ type HTMLVisualMediaElement = HTMLVideoElement | HTMLImageElement;
  */
 export class BrowserCodeReader {
 
-    /**
-     * If navigator is present.
-     */
-    public get hasNavigator() {
-        return typeof navigator !== 'undefined';
-    }
+  /**
+   * If navigator is present.
+   */
+  public get hasNavigator() {
+    return typeof navigator !== 'undefined';
+  }
 
-    public get isMediaDevicesSuported() {
-        return this.hasNavigator && !!navigator.mediaDevices;
-    }
+  public get isMediaDevicesSuported() {
+    return this.hasNavigator && !!navigator.mediaDevices;
+  }
 
-    public get canEnumerateDevices() {
-        return !!(this.isMediaDevicesSuported && navigator.mediaDevices.enumerateDevices);
-    }
+  public get canEnumerateDevices() {
+    return !!(this.isMediaDevicesSuported && navigator.mediaDevices.enumerateDevices);
+  }
 
-    /**
-     * The HTML canvas element, used to draw the video or image's frame for decoding.
-     */
-    protected captureCanvas: HTMLCanvasElement;
-    /**
-     * The HTML canvas element context.
-     */
-    protected captureCanvasContext: CanvasRenderingContext2D;
+  /**
+   * The HTML canvas element, used to draw the video or image's frame for decoding.
+   */
+  protected captureCanvas: HTMLCanvasElement;
+  /**
+   * The HTML canvas element context.
+   */
+  protected captureCanvasContext: CanvasRenderingContext2D;
 
-    /**
-     * The HTML image element, used as a fallback for the video element when decoding.
-     */
-    protected imageElement: HTMLImageElement;
+  /**
+   * The HTML image element, used as a fallback for the video element when decoding.
+   */
+  protected imageElement: HTMLImageElement;
 
-    /**
-     * Should contain the current registered listener for image loading,
-     * used to unregister that listener when needed.
-     */
-    protected imageLoadedEventListener: EventListener;
+  /**
+   * Should contain the current registered listener for image loading,
+   * used to unregister that listener when needed.
+   */
+  protected imageLoadedEventListener: EventListener;
 
-    /**
-     * The stream output from camera.
-     */
-    protected stream: MediaStream;
+  /**
+   * The stream output from camera.
+   */
+  protected stream: MediaStream;
 
-    /**
-     * Some timeout's Id.
-     */
-    protected timeoutHandler: number;
+  /**
+   * Some timeout's Id.
+   */
+  protected timeoutHandler: number;
 
-    /**
-     * The HTML video element, used to display the camera stream.
-     */
-    protected videoElement: HTMLVideoElement;
+  /**
+   * The HTML video element, used to display the camera stream.
+   */
+  protected videoElement: HTMLVideoElement;
 
-    /**
-     * Should contain the current registered listener for video loaded-metadata,
-     * used to unregister that listener when needed.
-     */
-    protected videoLoadedMetadataEventListener: EventListener;
+  /**
+   * Should contain the current registered listener for video loaded-metadata,
+   * used to unregister that listener when needed.
+   */
+  protected videoLoadedMetadataEventListener: EventListener;
 
-    /**
-     * Should contain the current registered listener for video play-ended,
-     * used to unregister that listener when needed.
-     */
-    protected videoPlayEndedEventListener: EventListener;
+  /**
+   * Should contain the current registered listener for video play-ended,
+   * used to unregister that listener when needed.
+   */
+  protected videoPlayEndedEventListener: EventListener;
 
-    /**
-     * Should contain the current registered listener for video playing,
-     * used to unregister that listener when needed.
+  /**
+   * Should contain the current registered listener for video playing,
+   * used to unregister that listener when needed.
    */
   protected videoPlayingEventListener: EventListener;
 
@@ -104,7 +104,7 @@ export class BrowserCodeReader {
   /**
    * Creates an instance of BrowserCodeReader.
    * @param {Reader} reader The reader instance to decode the barcode
-     * @param {number} [timeBetweenScansMillis=500] the time delay between subsequent decode tries
+   * @param {number} [timeBetweenScansMillis=500] the time delay between subsequent decode tries
    *
    * @memberOf BrowserCodeReader
    */
@@ -112,176 +112,177 @@ export class BrowserCodeReader {
 
   /**
    * Lists all the available video input devices.
-     */
-    public async listVideoInputDevices(): Promise<MediaDeviceInfo[]> {
+   */
+  public async listVideoInputDevices(): Promise<MediaDeviceInfo[]> {
 
-        if (!this.hasNavigator) {
-            throw new Error('Can\'t enumerate devices, navigator is not present.');
-        }
-
-        if (!this.canEnumerateDevices) {
-            throw new Error('Can\'t enumerate devices, method not supported.');
-        }
-
-        const devices = await navigator.mediaDevices.enumerateDevices();
-
-        const videoDevices: MediaDeviceInfo[] = [];
-
-        for (const device of devices) {
-
-            const kind = <string>device.kind === 'video' ? 'videoinput' : device.kind;
-
-            if (kind !== 'videoinput') {
-                continue;
-            }
-
-            const deviceId = device.deviceId || (<any>device).id;
-            const label = device.label || `Video device ${videoDevices.length + 1}`;
-            const groupId = device.groupId;
-
-            const videoDevice: MediaDeviceInfo = { deviceId, label, kind, groupId };
-
-            videoDevices.push(videoDevice);
-        }
-
-        return videoDevices;
+    if (!this.hasNavigator) {
+      throw new Error('Can\'t enumerate devices, navigator is not present.');
     }
 
-
-    /**
-     * Obtain the list of available devices with type 'videoinput'.
-     *
-     * @returns {Promise<VideoInputDevice[]>} an array of available video input devices
-     *
-     * @memberOf BrowserCodeReader
-     *
-     * @deprecated Use `discoverVideoInputDevices` instead.
-     */
-    public async getVideoInputDevices(): Promise<VideoInputDevice[]> {
-
-        const devices = await this.listVideoInputDevices();
-
-        return devices.map(d => new VideoInputDevice(d.deviceId, d.label));
+    if (!this.canEnumerateDevices) {
+      throw new Error('Can\'t enumerate devices, method not supported.');
     }
 
-    /**
-     * Let's you find a device using it's Id.
-     */
-    public async findDeviceById(deviceId: string): Promise<MediaDeviceInfo> {
+    const devices = await navigator.mediaDevices.enumerateDevices();
 
-      const devices = await this.listVideoInputDevices();
+    const videoDevices: MediaDeviceInfo[] = [];
 
-      if (!devices) {
-        return null;
+    for (const device of devices) {
+
+      const kind = <string>device.kind === 'video' ? 'videoinput' : device.kind;
+
+      if (kind !== 'videoinput') {
+        continue;
       }
 
-      return devices.find(x => x.deviceId === deviceId);
+      const deviceId = device.deviceId || (<any>device).id;
+      const label = device.label || `Video device ${videoDevices.length + 1}`;
+      const groupId = device.groupId;
+
+      const videoDevice: MediaDeviceInfo = { deviceId, label, kind, groupId };
+
+      videoDevices.push(videoDevice);
     }
 
-    /**
-     * Decodes the barcode from the device specified by deviceId while showing the video in the specified video element.
-     *
-     * @param {string} [deviceId] the id of one of the devices obtained after calling getVideoInputDevices. Can be undefined, in this case it will decode from one of the available devices, preffering the main camera (environment facing) if available.
-     * @param {string|HTMLVideoElement} [video] the video element in page where to show the video while decoding. Can be either an element id or directly an HTMLVideoElement. Can be undefined, in which case no video will be shown.
-     * @returns {Promise<Result>} The decoding result.
-     *
-     * @memberOf BrowserCodeReader
-     */
-    public async decodeFromInputVideoDevice(deviceId?: string, videoSource?: string | HTMLVideoElement): Promise<Result> {
+    return videoDevices;
+  }
 
-        this.reset();
 
-        let videoConstraints: MediaTrackConstraints;
+  /**
+   * Obtain the list of available devices with type 'videoinput'.
+   *
+   * @returns {Promise<VideoInputDevice[]>} an array of available video input devices
+   *
+   * @memberOf BrowserCodeReader
+   *
+   * @deprecated Use `discoverVideoInputDevices` instead.
+   */
+  public async getVideoInputDevices(): Promise<VideoInputDevice[]> {
 
-        if (!deviceId) {
-            videoConstraints = { facingMode: 'environment' };
-        } else {
-            videoConstraints = { deviceId: { exact: deviceId } };
-        }
+    const devices = await this.listVideoInputDevices();
 
-        const constraints: MediaStreamConstraints = { video: videoConstraints };
+    return devices.map(d => new VideoInputDevice(d.deviceId, d.label));
+  }
 
-        const stream = await navigator.mediaDevices.getUserMedia(constraints);
-        const video = await this.attachStreamToVideo(stream, videoSource);
+  /**
+   * Let's you find a device using it's Id.
+   */
+  public async findDeviceById(deviceId: string): Promise<MediaDeviceInfo> {
 
-        return new Promise((resolve, reject) => this.decodeWithRetryAndDelay(video, resolve, reject));
+    const devices = await this.listVideoInputDevices();
+
+    if (!devices) {
+      return null;
     }
 
-    /**
-     * Sets the new stream and request a new decoding-with-delay.
-     *
-     * @param stream The stream to be shown in the video element.
-     * @param decodeFn A callback for the decode method.
-     *
-     * @todo Return Promise<Result>
-     */
-    protected async attachStreamToVideo(stream: MediaStream, videoSource: string | HTMLVideoElement): Promise<HTMLVideoElement> {
+    return devices.find(x => x.deviceId === deviceId);
+  }
 
-        this.reset();
+  /**
+   * Decodes the barcode from the device specified by deviceId while showing the video in the specified video element.
+   *
+   * @param {string} [deviceId] the id of one of the devices obtained after calling getVideoInputDevices. Can be undefined, in this case it will decode from one of the available devices, preffering the main camera (environment facing) if available.
+   * @param {string|HTMLVideoElement} [video] the video element in page where to show the video while decoding. Can be either an element id or directly an HTMLVideoElement. Can be undefined, in which case no video will be shown.
+   * @returns {Promise<Result>} The decoding result.
+   *
+   * @memberOf BrowserCodeReader
+   */
+  public async decodeFromInputVideoDevice(deviceId?: string, videoSource?: string | HTMLVideoElement): Promise<Result> {
 
-        const videoElement = this.prepareVideoElement(videoSource);
+    this.reset();
 
-        this.addVideoSource(videoElement, stream);
+    let videoConstraints: MediaTrackConstraints;
 
-        this.videoElement = videoElement;
-        this.stream = stream;
-
-        await this.playVideoAsync(videoElement);
-
-        return videoElement;
+    if (!deviceId) {
+      videoConstraints = { facingMode: 'environment' };
+    } else {
+      videoConstraints = { deviceId: { exact: deviceId } };
     }
 
-    /**
-     *
-     * @param videoElement
-     */
-    playVideoAsync(videoElement: HTMLVideoElement): Promise<void> {
-        return new Promise((resolve, reject) => this.playVideo(videoElement, () => resolve()));
-    }
+    const constraints: MediaStreamConstraints = { video: videoConstraints };
 
-    /**
-     * Binds listeners and callbacks to the videoElement.
-     *
-     * @param videoElement
-     * @param callbackFn
-     */
-    protected playVideo(videoElement: HTMLVideoElement, playCallback: EventListener): void {
+    const stream = await navigator.mediaDevices.getUserMedia(constraints);
+    const video = await this.attachStreamToVideo(stream, videoSource);
+    const result = await this.decodeWithRetry(video);
 
-        videoElement.addEventListener('playing', playCallback);
+    return result;
+  }
 
-        this.videoLoadedMetadataEventListener = () => videoElement.play();
+  /**
+   * Sets the new stream and request a new decoding-with-delay.
+   *
+   * @param stream The stream to be shown in the video element.
+   * @param decodeFn A callback for the decode method.
+   *
+   * @todo Return Promise<Result>
+   */
+  protected async attachStreamToVideo(stream: MediaStream, videoSource: string | HTMLVideoElement): Promise<HTMLVideoElement> {
 
-        videoElement.addEventListener('loadedmetadata', this.videoLoadedMetadataEventListener);
-    }
+    this.reset();
 
-    /**
-     * Decodes a barcode form a video url.
-     *
-     * @param {string} videoUrl The video url to decode from, required.
-     * @param {(string|HTMLVideoElement)} [videoElement] The video element where to play the video while decoding. Can be undefined in which case no video is shown.
-     * @returns {Promise<Result>} The decoding result.
-     *
-     * @memberOf BrowserCodeReader
-     */
-    public decodeFromVideoSource(videoUrl: string, videoElement?: string | HTMLVideoElement): Promise<Result> {
-        return new Promise<Result>((resolve, reject) => this._decodeFromVideoSource(videoElement, reject, resolve, videoUrl));
-    }
+    const videoElement = this.prepareVideoElement(videoSource);
 
-    /**
-     *
-     */
-    private _decodeFromVideoSource(videoSource: string | HTMLVideoElement, reject: (reason?: any) => void, resolve: (value?: Result | PromiseLike<Result>) => void, videoUrl: string) {
+    this.addVideoSource(videoElement, stream);
 
-        this.reset();
+    this.videoElement = videoElement;
+    this.stream = stream;
 
-        const videoElement = this.prepareVideoElement(videoSource);
+    await this.playVideoAsync(videoElement);
 
-        this.videoPlayEndedEventListener = () => {
-            this.stopStreams();
+    return videoElement;
+  }
+
+  /**
+   *
+   * @param videoElement
+   */
+  protected playVideoAsync(videoElement: HTMLVideoElement): Promise<void> {
+    return new Promise((resolve, reject) => this.playVideo(videoElement, () => resolve()));
+  }
+
+  /**
+   * Binds listeners and callbacks to the videoElement.
+   *
+   * @param videoElement
+   * @param callbackFn
+   */
+  protected playVideo(videoElement: HTMLVideoElement, playCallback: EventListener): void {
+
+    videoElement.addEventListener('playing', playCallback);
+
+    this.videoLoadedMetadataEventListener = () => videoElement.play();
+
+    videoElement.addEventListener('loadedmetadata', this.videoLoadedMetadataEventListener);
+  }
+
+  /**
+   * Decodes a barcode form a video url.
+   *
+   * @param {string} videoUrl The video url to decode from, required.
+   * @param {(string|HTMLVideoElement)} [videoElement] The video element where to play the video while decoding. Can be undefined in which case no video is shown.
+   * @returns {Promise<Result>} The decoding result.
+   *
+   * @memberOf BrowserCodeReader
+   */
+  public decodeFromVideoSource(videoUrl: string, videoElement?: string | HTMLVideoElement): Promise<Result> {
+    return new Promise<Result>((resolve, reject) => this._decodeFromVideoSource(videoElement, reject, resolve, videoUrl));
+  }
+
+  /**
+   *
+   */
+  private _decodeFromVideoSource(videoSource: string | HTMLVideoElement, reject: (reason?: any) => void, resolve: (value?: Result | PromiseLike<Result>) => void, videoUrl: string) {
+
+    this.reset();
+
+    const videoElement = this.prepareVideoElement(videoSource);
+
+    this.videoPlayEndedEventListener = () => {
+      this.stopStreams();
       reject(new NotFoundException('Video stream has ended before any code could be detected.'));
     };
 
-    this.videoPlayingEventListener = () => this.decodeWithRetryAndDelay(videoElement, resolve, reject);
+    this.videoPlayingEventListener = () => this.decodeWithRetry(videoElement).then(resolve, reject);
 
     // defines the video element before starts decoding
     this.videoElement = videoElement;
@@ -294,122 +295,122 @@ export class BrowserCodeReader {
   }
 
   /**
-     * Sets a HTMLVideoElement for scanning or creates a new one.
-     *
-     * @param videoSrc The HTMLVideoElement to be set.
-     */
-    protected prepareVideoElement(videoSrc?: HTMLVideoElement | string): HTMLVideoElement {
+   * Sets a HTMLVideoElement for scanning or creates a new one.
+   *
+   * @param videoSrc The HTMLVideoElement to be set.
+   */
+  protected prepareVideoElement(videoSrc?: HTMLVideoElement | string): HTMLVideoElement {
 
-        let videoElement: HTMLVideoElement;
+    let videoElement: HTMLVideoElement;
 
-        if (!videoSrc && typeof document !== 'undefined') {
-            videoElement = document.createElement('video');
-            videoElement.width = 200;
-            videoElement.height = 200;
-        }
-
-        if (typeof videoSrc === 'string') {
-            videoElement = <HTMLVideoElement>this.getMediaElement(videoSrc, 'video');
-        }
-
-        if (videoSrc instanceof HTMLVideoElement) {
-            videoElement = videoSrc;
-        }
-
-        // Needed for iOS 11
-        videoElement.setAttribute('autoplay', 'true');
-        videoElement.setAttribute('muted', 'true');
-        videoElement.setAttribute('playsinline', 'true');
-
-        return videoElement;
+    if (!videoSrc && typeof document !== 'undefined') {
+      videoElement = document.createElement('video');
+      videoElement.width = 200;
+      videoElement.height = 200;
     }
 
-    /**
-     * Searches and validates a media element.
-     */
-    protected getMediaElement(mediaElementId: string, type: string): HTMLVisualMediaElement {
-
-        const mediaElement = document.getElementById(mediaElementId);
-
-        if (!mediaElement) {
-            throw new ArgumentException(`element with id '${mediaElementId}' not found`);
-        }
-
-        if (mediaElement.nodeName.toLowerCase() !== type.toLowerCase()) {
-            throw new ArgumentException(`element with id '${mediaElementId}' must be an ${type} element`);
-        }
-
-        return <HTMLVisualMediaElement>mediaElement;
+    if (typeof videoSrc === 'string') {
+      videoElement = <HTMLVideoElement>this.getMediaElement(videoSrc, 'video');
     }
 
-    /**
-     * Decodes the barcode from an image.
-     *
-     * @param {(string|HTMLImageElement)} [imageElement] The image element that can be either an element id or the element itself. Can be undefined in which case the decoding will be done from the imageUrl parameter.
-     * @param {string} [imageUrl]
-     * @returns {Promise<Result>} The decoding result.
-     *
-     * @memberOf BrowserCodeReader
-     */
-    public decodeFromImage(imageElement?: string | HTMLImageElement, imageUrl?: string): Promise<Result> {
-
-        if (undefined === imageElement && undefined === imageUrl) {
-            throw new ArgumentException('either imageElement with a src set or an url must be provided');
-        }
-
-        if (imageUrl && !imageElement) {
-            return this.decodeFromImageUrl(imageUrl);
-        }
-
-        return this.decodeFromImageElement(imageElement, imageUrl);
+    if (videoSrc instanceof HTMLVideoElement) {
+      videoElement = videoSrc;
     }
 
-    /**
-     * Decodes something from an image HTML element.
-     */
-    public decodeFromImageElement(imageElement: string | HTMLImageElement, imageUrl: string) {
-        return new Promise<Result>((resolve, reject) => this._decodeFromImageElement(imageElement, resolve, reject));
+    // Needed for iOS 11
+    videoElement.setAttribute('autoplay', 'true');
+    videoElement.setAttribute('muted', 'true');
+    videoElement.setAttribute('playsinline', 'true');
+
+    return videoElement;
+  }
+
+  /**
+   * Searches and validates a media element.
+   */
+  protected getMediaElement(mediaElementId: string, type: string): HTMLVisualMediaElement {
+
+    const mediaElement = document.getElementById(mediaElementId);
+
+    if (!mediaElement) {
+      throw new ArgumentException(`element with id '${mediaElementId}' not found`);
     }
 
-    /**
-     * Promise constructor.
-     */
-    private _decodeFromImageElement(imageElement: string | HTMLImageElement, resolve: (value?: Result | PromiseLike<Result>) => void, reject: (reason?: any) => void) {
+    if (mediaElement.nodeName.toLowerCase() !== type.toLowerCase()) {
+      throw new ArgumentException(`element with id '${mediaElementId}' must be an ${type} element`);
+    }
 
-        if (!imageElement) {
-            throw new ArgumentException('An image element must be provided.');
-        }
+    return <HTMLVisualMediaElement>mediaElement;
+  }
 
-        this.reset();
+  /**
+   * Decodes the barcode from an image.
+   *
+   * @param {(string|HTMLImageElement)} [imageElement] The image element that can be either an element id or the element itself. Can be undefined in which case the decoding will be done from the imageUrl parameter.
+   * @param {string} [imageUrl]
+   * @returns {Promise<Result>} The decoding result.
+   *
+   * @memberOf BrowserCodeReader
+   */
+  public decodeFromImage(imageElement?: string | HTMLImageElement, imageUrl?: string): Promise<Result> {
+
+    if (undefined === imageElement && undefined === imageUrl) {
+      throw new ArgumentException('either imageElement with a src set or an url must be provided');
+    }
+
+    if (imageUrl && !imageElement) {
+      return this.decodeFromImageUrl(imageUrl);
+    }
+
+    return this.decodeFromImageElement(imageElement, imageUrl);
+  }
+
+  /**
+   * Decodes something from an image HTML element.
+   */
+  public decodeFromImageElement(imageElement: string | HTMLImageElement, imageUrl: string) {
+    return new Promise<Result>((resolve, reject) => this._decodeFromImageElement(imageElement, resolve, reject));
+  }
+
+  /**
+   * Promise constructor.
+   */
+  private _decodeFromImageElement(imageElement: string | HTMLImageElement, resolve: (value?: Result | PromiseLike<Result>) => void, reject: (reason?: any) => void) {
+
+    if (!imageElement) {
+      throw new ArgumentException('An image element must be provided.');
+    }
+
+    this.reset();
 
     const image = this.prepareImageElement(imageElement);
 
     this.imageElement = image;
 
     if (this.isImageLoaded(image)) {
-      this.decodeWithRetry(image, resolve, reject, false, true);
+      this.decodeWithRetry(image, false, true).then(resolve, reject);
     } else {
       this._decodeOnLoadImage(image, resolve, reject);
     }
   }
 
   /**
-     * Decodes an image from a URL.
-     */
-    public decodeFromImageUrl(imageUrl?: string): Promise<Result> {
-        return new Promise<Result>((resolve, reject) => this._decodeFromImageUrl(imageUrl, resolve, reject));
+   * Decodes an image from a URL.
+   */
+  public decodeFromImageUrl(imageUrl?: string): Promise<Result> {
+    return new Promise<Result>((resolve, reject) => this._decodeFromImageUrl(imageUrl, resolve, reject));
+  }
+
+  /**
+   * Promise constructor.
+   */
+  private _decodeFromImageUrl(imageUrl: string, resolve: (value?: Result | PromiseLike<Result>) => void, reject: (reason?: any) => void) {
+
+    if (!imageUrl) {
+      throw new ArgumentException('An URL must be provided.');
     }
 
-    /**
-     * Promise constructor.
-     */
-    private _decodeFromImageUrl(imageUrl: string, resolve: (value?: Result | PromiseLike<Result>) => void, reject: (reason?: any) => void) {
-
-        if (!imageUrl) {
-            throw new ArgumentException('An URL must be provided.');
-        }
-
-        this.reset();
+    this.reset();
 
     const image = this.prepareImageElement();
 
@@ -421,90 +422,92 @@ export class BrowserCodeReader {
   }
 
   private _decodeOnLoadImage(imageElement: HTMLImageElement, resolve: (value?: Result | PromiseLike<Result>) => void, reject: (reason?: any) => void) {
-        this.imageLoadedEventListener = () => this.decodeWithRetry(imageElement, resolve, reject, false, true);
-        imageElement.addEventListener('load', this.imageLoadedEventListener);
+    this.imageLoadedEventListener = () => this.decodeWithRetry(imageElement, false, true).then(resolve, reject);
+    imageElement.addEventListener('load', this.imageLoadedEventListener);
+  }
+
+  protected isImageLoaded(img: HTMLImageElement) {
+    // During the onload event, IE correctly identifies any images that
+    // weren’t downloaded as not complete. Others should too. Gecko-based
+    // browsers act like NS4 in that they report this incorrectly.
+    if (!img.complete) {
+      return false;
     }
 
-    protected isImageLoaded(img: HTMLImageElement) {
-        // During the onload event, IE correctly identifies any images that
-        // weren’t downloaded as not complete. Others should too. Gecko-based
-        // browsers act like NS4 in that they report this incorrectly.
-        if (!img.complete) {
-            return false;
-        }
+    // However, they do have two very useful properties: naturalWidth and
+    // naturalHeight. These give the true size of the image. If it failed
+    // to load, either of these should be zero.
 
-        // However, they do have two very useful properties: naturalWidth and
-        // naturalHeight. These give the true size of the image. If it failed
-        // to load, either of these should be zero.
-
-        if (img.naturalWidth === 0) {
-            return false;
-        }
-
-        // No other way of checking: assume it’s ok.
-        return true;
+    if (img.naturalWidth === 0) {
+      return false;
     }
 
-    protected prepareImageElement(imageSrc?: HTMLImageElement | string): HTMLImageElement {
+    // No other way of checking: assume it’s ok.
+    return true;
+  }
 
-        let imageElement: HTMLImageElement;
+  protected prepareImageElement(imageSrc?: HTMLImageElement | string): HTMLImageElement {
 
-        if (typeof imageSrc === 'undefined') {
-            imageElement = document.createElement('img');
-            imageElement.width = 200;
-            imageElement.height = 200;
-        }
+    let imageElement: HTMLImageElement;
 
-        if (typeof imageSrc === 'string') {
-            imageElement = <HTMLImageElement>this.getMediaElement(imageSrc, 'img');
-        }
-
-        if (imageSrc instanceof HTMLImageElement) {
-            imageElement = imageSrc;
-        }
-
-        return imageElement;
+    if (typeof imageSrc === 'undefined') {
+      imageElement = document.createElement('img');
+      imageElement.width = 200;
+      imageElement.height = 200;
     }
 
-    private decodeWithRetryAndDelay(element: HTMLVisualMediaElement, resolve: (result: Result) => any, reject: (error: any) => any): void {
-        this.timeoutHandler = window.setTimeout(() => this.decodeWithRetry(element, resolve, reject), this.timeBetweenScansMillis);
+    if (typeof imageSrc === 'string') {
+      imageElement = <HTMLImageElement>this.getMediaElement(imageSrc, 'img');
     }
 
-    private decodeWithRetry(element: HTMLVisualMediaElement, resolve: (result: Result) => any, reject: (error: any) => any, retryIfNotFound = true, retryIfChecksumOrFormatError = true): void {
-
-        try {
-            const result = this.decode(element);
-            resolve(result);
-        } catch (e) {
-
-            const ifNotFound = retryIfNotFound && e instanceof NotFoundException;
-            const isChecksumOrFormatError = e instanceof ChecksumException || e instanceof FormatException;
-            const ifChecksumOrFormat = isChecksumOrFormatError && retryIfChecksumOrFormatError;
-
-            if (ifNotFound || ifChecksumOrFormat) {
-                // trying again
-                this.decodeWithRetryAndDelay(element, resolve, reject);
-            } else {
-                reject(e);
-            }
-        }
+    if (imageSrc instanceof HTMLImageElement) {
+      imageElement = imageSrc;
     }
 
-    /**
-     * Gets the BinaryBitmap for ya! (and decodes it)
-     */
-    protected decode(element: HTMLVisualMediaElement): Result {
+    return imageElement;
+  }
 
-        // get binary bitmap for decode function
-        const binaryBitmap = this.createBinaryBitmap(element);
+  /**
+   * Continuously decodes from video input.
+   */
+  private async decodeWithRetry(element: HTMLVisualMediaElement, retryIfNotFound = true, retryIfChecksumOrFormatError = true): Promise<Result> {
 
-        return this.decodeBitmap(binaryBitmap);
+    let result: Result;
+
+    try {
+      result = this.decode(element);
+    } catch (e) {
+
+      const ifNotFound = retryIfNotFound && e instanceof NotFoundException;
+      const isChecksumOrFormatError = e instanceof ChecksumException || e instanceof FormatException;
+      const ifChecksumOrFormat = isChecksumOrFormatError && retryIfChecksumOrFormatError;
+
+      if (ifNotFound || ifChecksumOrFormat) {
+        // trying again
+        result = await this.decodeWithRetry(element, retryIfNotFound, retryIfChecksumOrFormatError);
+      } else {
+        throw e;
+      }
     }
 
-    /**
-     * Creates a binaryBitmap based in some image source.
-     *
-     * @param mediaElement HTML element containing drawable image source.
+    return result;
+  }
+
+  /**
+   * Gets the BinaryBitmap for ya! (and decodes it)
+   */
+  protected decode(element: HTMLVisualMediaElement): Result {
+
+    // get binary bitmap for decode function
+    const binaryBitmap = this.createBinaryBitmap(element);
+
+    return this.decodeBitmap(binaryBitmap);
+  }
+
+  /**
+   * Creates a binaryBitmap based in some image source.
+   *
+   * @param mediaElement HTML element containing drawable image source.
    */
   protected createBinaryBitmap(mediaElement: HTMLVisualMediaElement): BinaryBitmap {
 
@@ -517,8 +520,8 @@ export class BrowserCodeReader {
     const luminanceSource = new HTMLCanvasElementLuminanceSource(canvas);
     const hybridBinarizer = new HybridBinarizer(luminanceSource);
 
-        return new BinaryBitmap(hybridBinarizer);
-    }
+    return new BinaryBitmap(hybridBinarizer);
+  }
 
   /**
    *
@@ -531,8 +534,8 @@ export class BrowserCodeReader {
       this.captureCanvasContext = ctx;
     }
 
-        return this.captureCanvasContext;
-    }
+    return this.captureCanvasContext;
+  }
 
   /**
    *
@@ -544,17 +547,17 @@ export class BrowserCodeReader {
       this.captureCanvas = elem;
     }
 
-        return this.captureCanvas;
-    }
+    return this.captureCanvas;
+  }
 
-    /**
-     * Ovewriting this allows you to manipulate the snapshot image in anyway you want before decode.
-     */
-    protected drawImageOnCanvas(canvasElementContext: CanvasRenderingContext2D, srcElement: HTMLVisualMediaElement) {
-        canvasElementContext.drawImage(srcElement, 0, 0);
-    }
+  /**
+   * Ovewriting this allows you to manipulate the snapshot image in anyway you want before decode.
+   */
+  protected drawImageOnCanvas(canvasElementContext: CanvasRenderingContext2D, srcElement: HTMLVisualMediaElement) {
+    canvasElementContext.drawImage(srcElement, 0, 0);
+  }
 
-    /**
+  /**
    * Call the encapsulated readers decode
    */
   protected decodeBitmap(binaryBitmap: BinaryBitmap): Result {
@@ -568,10 +571,10 @@ export class BrowserCodeReader {
 
     if (typeof document === 'undefined') {
       this._destroyCaptureCanvas();
-            return null;
-        }
+      return null;
+    }
 
-        const canvasElement = document.createElement('canvas');
+    const canvasElement = document.createElement('canvas');
 
     let width: number;
     let height: number;
@@ -587,130 +590,130 @@ export class BrowserCodeReader {
     }
 
     canvasElement.style.width = width + 'px';
-        canvasElement.style.height = height + 'px';
-        canvasElement.width = width;
-        canvasElement.height = height;
+    canvasElement.style.height = height + 'px';
+    canvasElement.width = width;
+    canvasElement.height = height;
 
-        return canvasElement;
+    return canvasElement;
+  }
+
+  /**
+   * Stops the continuous scan and cleans the stream.
+   */
+  protected stopStreams(): void {
+    if (this.stream) {
+      this.stream.getVideoTracks().forEach(t => t.stop());
+      this.stream = undefined;
+    }
+  }
+
+  /**
+   * Resets the code reader to the initial state. Cancels any ongoing barcode scanning from video or camera.
+   *
+   * @memberOf BrowserCodeReader
+   */
+  public reset() {
+
+    window.clearTimeout(this.timeoutHandler);
+
+    // stops the camera, preview and scan 🔴
+
+    this.stopStreams();
+
+    // clean and forget about HTML elements
+
+    this._destroyVideoElement();
+    this._destroyImageElement();
+    this._destroyCaptureCanvas();
+  }
+
+  private _destroyVideoElement(): void {
+
+    if (!this.videoElement) {
+      return;
     }
 
-    /**
-     * Stops the continuous scan and cleans the stream.
-     */
-    protected stopStreams(): void {
-        if (this.stream) {
-            this.stream.getVideoTracks().forEach(t => t.stop());
-            this.stream = undefined;
-        }
+    // first gives freedon to the element 🕊
+
+    if (typeof this.videoPlayEndedEventListener !== 'undefined') {
+      this.videoElement.removeEventListener('ended', this.videoPlayEndedEventListener);
     }
 
-    /**
-     * Resets the code reader to the initial state. Cancels any ongoing barcode scanning from video or camera.
-     *
-     * @memberOf BrowserCodeReader
-     */
-    public reset() {
-
-        window.clearTimeout(this.timeoutHandler);
-
-        // stops the camera, preview and scan 🔴
-
-        this.stopStreams();
-
-        // clean and forget about HTML elements
-
-        this._destroyVideoElement();
-        this._destroyImageElement();
-        this._destroyCaptureCanvas();
+    if (typeof this.videoPlayingEventListener !== 'undefined') {
+      this.videoElement.removeEventListener('playing', this.videoPlayingEventListener);
     }
 
-    private _destroyVideoElement(): void {
-
-        if (!this.videoElement) {
-            return;
-        }
-
-        // first gives freedon to the element 🕊
-
-        if (typeof this.videoPlayEndedEventListener !== 'undefined') {
-            this.videoElement.removeEventListener('ended', this.videoPlayEndedEventListener);
-        }
-
-        if (typeof this.videoPlayingEventListener !== 'undefined') {
-            this.videoElement.removeEventListener('playing', this.videoPlayingEventListener);
-        }
-
-        if (typeof this.videoLoadedMetadataEventListener !== 'undefined') {
-            this.videoElement.removeEventListener('loadedmetadata', this.videoLoadedMetadataEventListener);
-        }
-
-        // then forgets about that element 😢
-
-        this.cleanVideoSource(this.videoElement);
-
-        this.videoElement = undefined;
+    if (typeof this.videoLoadedMetadataEventListener !== 'undefined') {
+      this.videoElement.removeEventListener('loadedmetadata', this.videoLoadedMetadataEventListener);
     }
 
-    private _destroyImageElement(): void {
+    // then forgets about that element 😢
 
-        if (!this.imageElement) {
-            return;
-        }
+    this.cleanVideoSource(this.videoElement);
 
-        // first gives freedon to the element 🕊
+    this.videoElement = undefined;
+  }
 
-        if (undefined !== this.imageLoadedEventListener) {
-            this.imageElement.removeEventListener('load', this.imageLoadedEventListener);
-        }
+  private _destroyImageElement(): void {
 
-        // then forget about that element 😢
-
-        this.imageElement.src = undefined;
-        this.imageElement.removeAttribute('src');
-        this.imageElement = undefined;
+    if (!this.imageElement) {
+      return;
     }
 
-    /**
-     * Cleans canvas references 🖌
-     */
-    private _destroyCaptureCanvas(): void {
+    // first gives freedon to the element 🕊
 
-        // then forget about that element 😢
-
-        this.captureCanvasContext = undefined;
-        this.captureCanvas = undefined;
+    if (undefined !== this.imageLoadedEventListener) {
+      this.imageElement.removeEventListener('load', this.imageLoadedEventListener);
     }
 
-    /**
-     * Defines what the videoElement src will be.
-     *
-     * @param videoElement
-     * @param stream
-     */
-    public addVideoSource(videoElement: HTMLVideoElement, stream: MediaStream): void {
-        // Older browsers may not have `srcObject`
-        try {
-            // @NOTE Throws Exception if interrupted by a new loaded request
-            videoElement.srcObject = stream;
-        } catch (err) {
-            // @NOTE Avoid using this in new browsers, as it is going away.
-            videoElement.src = window.URL.createObjectURL(stream);
-        }
+    // then forget about that element 😢
+
+    this.imageElement.src = undefined;
+    this.imageElement.removeAttribute('src');
+    this.imageElement = undefined;
+  }
+
+  /**
+   * Cleans canvas references 🖌
+   */
+  private _destroyCaptureCanvas(): void {
+
+    // then forget about that element 😢
+
+    this.captureCanvasContext = undefined;
+    this.captureCanvas = undefined;
+  }
+
+  /**
+   * Defines what the videoElement src will be.
+   *
+   * @param videoElement
+   * @param stream
+   */
+  public addVideoSource(videoElement: HTMLVideoElement, stream: MediaStream): void {
+    // Older browsers may not have `srcObject`
+    try {
+      // @NOTE Throws Exception if interrupted by a new loaded request
+      videoElement.srcObject = stream;
+    } catch (err) {
+      // @NOTE Avoid using this in new browsers, as it is going away.
+      videoElement.src = window.URL.createObjectURL(stream);
+    }
+  }
+
+  /**
+   * Unbinds a HTML video src property.
+   *
+   * @param videoElement
+   */
+  private cleanVideoSource(videoElement: HTMLVideoElement): void {
+
+    try {
+      videoElement.srcObject = null;
+    } catch (err) {
+      videoElement.src = '';
     }
 
-    /**
-     * Unbinds a HTML video src property.
-     *
-     * @param videoElement
-     */
-    private cleanVideoSource(videoElement: HTMLVideoElement): void {
-
-        try {
-            videoElement.srcObject = null;
-        } catch (err) {
-            videoElement.src = '';
-        }
-
-        this.videoElement.removeAttribute('src');
-    }
+    this.videoElement.removeAttribute('src');
+  }
 }

--- a/src/browser/ContinuousDecodeCallback.ts
+++ b/src/browser/ContinuousDecodeCallback.ts
@@ -1,0 +1,7 @@
+import Exception from '../core/Exception';
+import Result from '../core/Result';
+
+/**
+ * Callback format for continuous decode scan.
+ */
+export type ContinuousDecodeCallback = (result: Result, error?: Exception) => any;

--- a/src/browser/DecodeContinuouslyCallback.ts
+++ b/src/browser/DecodeContinuouslyCallback.ts
@@ -4,4 +4,4 @@ import Result from '../core/Result';
 /**
  * Callback format for continuous decode scan.
  */
-export type ContinuousDecodeCallback = (result: Result, error?: Exception) => any;
+export type DecodeContinuouslyCallback = (result: Result, error?: Exception) => any;

--- a/src/browser/HTMLVisualMediaElement.ts
+++ b/src/browser/HTMLVisualMediaElement.ts
@@ -1,0 +1,4 @@
+/**
+ * HTML elements that can be decoded.
+ */
+export type HTMLVisualMediaElement = HTMLVideoElement | HTMLImageElement;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,18 +1,20 @@
 // browser
-export * from './browser/BrowserQRCodeReader';
-export * from './browser/BrowserDatamatrixCodeReader';
-export * from './browser/BrowserQRCodeSvgWriter';
 export * from './browser/BrowserBarcodeReader';
 export * from './browser/BrowserCodeReader';
+export * from './browser/BrowserDatamatrixCodeReader';
 export * from './browser/BrowserMultiFormatReader';
+export * from './browser/BrowserQRCodeReader';
+export * from './browser/BrowserQRCodeSvgWriter';
+export * from './browser/ContinuousDecodeCallback';
 export * from './browser/HTMLCanvasElementLuminanceSource';
+export * from './browser/HTMLVisualMediaElement';
 export * from './browser/VideoInputDevice';
 
 // Exceptions
-export { default as Exception } from './core/Exception';
 export { default as ArgumentException } from './core/ArgumentException';
 export { default as ArithmeticException } from './core/ArithmeticException';
 export { default as ChecksumException } from './core/ChecksumException';
+export { default as Exception } from './core/Exception';
 export { default as FormatException } from './core/FormatException';
 export { default as IllegalArgumentException } from './core/IllegalArgumentException';
 export { default as IllegalStateException } from './core/IllegalStateException';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export * from './browser/BrowserDatamatrixCodeReader';
 export * from './browser/BrowserMultiFormatReader';
 export * from './browser/BrowserQRCodeReader';
 export * from './browser/BrowserQRCodeSvgWriter';
-export * from './browser/ContinuousDecodeCallback';
+export * from './browser/DecodeContinuouslyCallback';
 export * from './browser/HTMLCanvasElementLuminanceSource';
 export * from './browser/HTMLVisualMediaElement';
 export * from './browser/VideoInputDevice';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6078,10 +6078,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.0.3, typescript@^3.3.3333:
+typescript@^3.0.3:
   version "3.3.3333"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
   integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==
+
+typescript@~3.3.3333:
+  version "3.3.4000"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
+  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
 
 uglify-js@^3.0.0, uglify-js@^3.1.4, uglify-js@^3.4.9:
   version "3.4.9"


### PR DESCRIPTION
- The much requested continuous decode for browser layer.
- Promisified some decode once methods.
- Little performance improvements.
- Bug fixes.
- **Continuous decode** for browser.
- Renamed `decodeFromVideoSource` to `decodeFromVideo`.
  - The parameters changed a little, but just by inverting them we achieve compatibility. This was made so the video decoding API could be closer to the image one.