### PR TITLE
Fix most occurences of `IndexSizeError` inside firefox

### DIFF
--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -324,7 +324,7 @@ export class BrowserCodeReader {
    */
   async tryPlayVideo(videoElement: HTMLVideoElement): Promise<void> {
 
-    if (!this.isVideoPLaying(videoElement)) {
+    if (this.isVideoPLaying(videoElement)) {
       console.warn('Trying yo play video that is already playing.');
       return;
     }

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -314,8 +314,8 @@ export class BrowserCodeReader {
   /**
    * Checks if the given video element is currently playing.
    */
-  isVideoPLaying(video: HTMLVideoElement): boolean {
-    return !!(video.currentTime > 0 && !video.paused && !video.ended && video.readyState > 2);
+  isVideoPlaying(video: HTMLVideoElement): boolean {
+    return video.currentTime > 0 && !video.paused && !video.ended && video.readyState > 2;
   }
 
   /**
@@ -324,8 +324,8 @@ export class BrowserCodeReader {
    */
   async tryPlayVideo(videoElement: HTMLVideoElement): Promise<void> {
 
-    if (this.isVideoPLaying(videoElement)) {
-      console.warn('Trying yo play video that is already playing.');
+    if (this.isVideoPlaying(videoElement)) {
+      console.warn('Trying to play video that is already playing.');
       return;
     }
 

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -699,17 +699,15 @@ export class BrowserCodeReader {
         setTimeout(() => loop(), this.timeBetweenScansMillis);
       } catch (e) {
 
+        callbackFn(null, e);
+
         const isChecksumOrFormatError = e instanceof ChecksumException || e instanceof FormatException;
         const isNotFound = e instanceof NotFoundException;
 
-        if (!isChecksumOrFormatError && !isNotFound) {
-          // not expected
-          throw e;
+        if (isChecksumOrFormatError || isNotFound) {
+          // trying again
+          setTimeout(() => loop(), 0);
         }
-
-        // trying again
-        callbackFn(null, e);
-        setTimeout(() => loop(), 0);
       }
     };
 


### PR DESCRIPTION
Fixes a logical error inside `tryPlayVideo` which prevented any attempts to start a non running video.

This fixes most of the occurrences but presumably not the underlying cause of the `IndexSizeError` in Firefox which is actually a race condition between the video loading process event `loadedmetadata` and the `createCaptureCanvas` method. (see https://github.com/zxing-js/library/issues/156#issuecomment-501674590).

Also used the chance to ...
 - add an example for continuous qr camera scanning.
 - fix a typo in the name of `isVideoPlaying`
 - fix a typo in one of the log messages in `tryPlayVideo`
 - sanitize the error callback handling in `decodeContinuously`

---

If required it would be no problem to split these changes into multiple merge requests.