### PR TITLE
Fixed documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ const reader = new MultiFormatReader();
 
 reader.setHints(hints);
 
-const luminanceSource = new RGBLuminanceSource(imgWidth, imgHeight, imgByteArray);
+const luminanceSource = new RGBLuminanceSource(imgByteArray, imgWidth, imgHeight);
 const binaryBitmap = new BinaryBitmap(new HybridBinarizer(luminanceSource));
 
 reader.decode(binaryBitmap);


### PR DESCRIPTION
The arguments shown in the documentation(README.md) for the RGBLuminanceSource function are not in the correct order. It should be `new RGBLuminanceSource(imgByteArray, imgWidth, imgHeight);` instead of `new RGBLuminanceSource(imgWidth, imgHeight,imgByteArray);`