### PR TITLE
Fix closure leak

### DIFF
--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -781,7 +781,7 @@ export class BrowserCodeReader {
 
         if (ifNotFound || ifChecksumOrFormat) {
           // trying again
-          return setTimeout(() => loop(resolve, reject), this._timeBetweenDecodingAttempts);
+          return setTimeout(loop, this._timeBetweenDecodingAttempts, resolve, reject);
         }
 
         reject(e);
@@ -808,7 +808,7 @@ export class BrowserCodeReader {
       try {
         const result = this.decode(element);
         callbackFn(result, null);
-        setTimeout(() => loop(), this.timeBetweenScansMillis);
+        setTimeout(loop, this.timeBetweenScansMillis);
       } catch (e) {
 
         callbackFn(null, e);
@@ -818,7 +818,7 @@ export class BrowserCodeReader {
 
         if (isChecksumOrFormatError || isNotFound) {
           // trying again
-          setTimeout(() => loop(), this._timeBetweenDecodingAttempts);
+          setTimeout(loop, this._timeBetweenDecodingAttempts);
         }
 
       }


### PR DESCRIPTION
BrowserCodeReader.decodeContinuously() creates a new closure every time loop() is called by wrapping it in an arrow function before passing it to setTimeout(). This causes closure leak because the new closure contains reference to the closure from the previous call, which in turn contains reference to closure from an even earlier call, preventing them from being garbage-collected. Fix this by passing loop() directly to setTimeout() instead.


BrowserCodeReader.decodeOnce() may also have the same problem, but fixing it is a bit more difficult because its loop() takes arguments.