### PR TITLE
Add WebWorker support for BigInt constructor

### DIFF
--- a/src/core/pdf417/decoder/DecodedBitStreamParser.ts
+++ b/src/core/pdf417/decoder/DecodedBitStreamParser.ts
@@ -66,6 +66,10 @@ function getBigIntConstructor(): BigIntConstructor {
     return global['BigInt'] || null;
   }
 
+  if (typeof self !== 'undefined') {
+    return self['BigInt'] || null;
+  }
+
   throw new Error('Can\'t search globals for BigInt!');
 }
 


### PR DESCRIPTION
Hello!
I am currently working on getting the library to scan & decode PDF417 barcodes in a web-worker.

I immediately ran into this issue here, where we search for BigInt only from `window` & `global`, but for web-workers there is only `self` (or globalThis).

I was able to scan & decode PDF417 barcodes successfully in the web-worker after adding `self`