### PR TITLE
Don't mark classes as deprecated

### DIFF
--- a/src/browser/BrowserBarcodeReader.ts
+++ b/src/browser/BrowserBarcodeReader.ts
@@ -3,8 +3,6 @@ import MultiFormatOneDReader from '../core/oned/MultiFormatOneDReader';
 import DecodeHintType from '../core/DecodeHintType';
 
 /**
- * @deprecated Moving to @zxing/browser
- *
  * Barcode reader reader to use from browser.
  */
 export class BrowserBarcodeReader extends BrowserCodeReader {

--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -13,8 +13,6 @@ import { HTMLVisualMediaElement } from './HTMLVisualMediaElement';
 import { VideoInputDevice } from './VideoInputDevice';
 
 /**
- * @deprecated Moving to @zxing/browser
- *
  * Base class for browser code reader.
  */
 export class BrowserCodeReader {

--- a/src/browser/BrowserDatamatrixCodeReader.ts
+++ b/src/browser/BrowserDatamatrixCodeReader.ts
@@ -2,8 +2,6 @@ import { BrowserCodeReader } from './BrowserCodeReader';
 import DataMatrixReader from '../core/datamatrix/DataMatrixReader';
 
 /**
- * @deprecated Moving to @zxing/browser
- *
  * QR Code reader to use from browser.
  */
 export class BrowserDatamatrixCodeReader extends BrowserCodeReader {

--- a/src/browser/BrowserPDF417Reader.ts
+++ b/src/browser/BrowserPDF417Reader.ts
@@ -2,8 +2,6 @@ import { BrowserCodeReader } from './BrowserCodeReader';
 import PDF417Reader from '../core/pdf417/PDF417Reader';
 
 /**
- * @deprecated Moving to @zxing/browser
- *
  * QR Code reader to use from browser.
  */
 export class BrowserPDF417Reader extends BrowserCodeReader {

--- a/src/browser/BrowserQRCodeReader.ts
+++ b/src/browser/BrowserQRCodeReader.ts
@@ -2,8 +2,6 @@ import { BrowserCodeReader } from './BrowserCodeReader';
 import QRCodeReader from '../core/qrcode/QRCodeReader';
 
 /**
- * @deprecated Moving to @zxing/browser
- *
  * QR Code reader to use from browser.
  */
 export class BrowserQRCodeReader extends BrowserCodeReader {

--- a/src/browser/BrowserQRCodeSvgWriter.ts
+++ b/src/browser/BrowserQRCodeSvgWriter.ts
@@ -5,9 +5,6 @@ import ErrorCorrectionLevel from '../core/qrcode/decoder/ErrorCorrectionLevel';
 import IllegalArgumentException from '../core/IllegalArgumentException';
 import IllegalStateException from '../core/IllegalStateException';
 
-/**
- * @deprecated Moving to @zxing/browser
- */
 class BrowserQRCodeSvgWriter {
 
     private static readonly QUIET_ZONE_SIZE = 4;

--- a/src/browser/BrowserSvgCodeWriter.ts
+++ b/src/browser/BrowserSvgCodeWriter.ts
@@ -5,9 +5,6 @@ import ErrorCorrectionLevel from '../core/qrcode/decoder/ErrorCorrectionLevel';
 import IllegalArgumentException from '../core/IllegalArgumentException';
 import IllegalStateException from '../core/IllegalStateException';
 
-/**
- * @deprecated Moving to @zxing/browser
- */
 abstract class BrowserSvgCodeWriter {
 
     /**

--- a/src/browser/HTMLCanvasElementLuminanceSource.ts
+++ b/src/browser/HTMLCanvasElementLuminanceSource.ts
@@ -2,9 +2,6 @@ import InvertedLuminanceSource from '../core/InvertedLuminanceSource';
 import LuminanceSource from '../core/LuminanceSource';
 import IllegalArgumentException from '../core/IllegalArgumentException';
 
-/**
- * @deprecated Moving to @zxing/browser
- */
 export class HTMLCanvasElementLuminanceSource extends LuminanceSource {
 
     private buffer: Uint8ClampedArray;

--- a/src/browser/VideoInputDevice.ts
+++ b/src/browser/VideoInputDevice.ts
@@ -1,6 +1,4 @@
 /**
- * @deprecated Moving to @zxing/browser
- *
  * Video input device metadata containing the id and label of the device if available.
  */
 export class VideoInputDevice implements MediaDeviceInfo {


### PR DESCRIPTION
Some IDEs use special formatting to indicate whether classes/methods are deprecated. This is to encourage users of a library to
switch to replacements

The suggested replacement `@zxing/browser` does not exist

Until there are other methods that should be used instead, marking classes as deprecated is not helpful for users of the library