### PR TITLE
Update RSSExpandedReader.ts

### DIFF
--- a/src/core/oned/rss/expanded/RSSExpandedReader.ts
+++ b/src/core/oned/rss/expanded/RSSExpandedReader.ts
@@ -104,7 +104,7 @@ export default class RSSExpandedReader extends AbstractRSSReader {
       return RSSExpandedReader.constructResult(this.decodeRow2pairs(rowNumber, row));
     } catch (e) {
       // OK
-      console.log(e);
+      //console.log(e);
     }
 
     this.pairs.length = 0;


### PR DESCRIPTION
Removed 
console.log(e)   in decodeRow()
that log continuously a not NotFoundException() message when using mutli (ie. BrowserMultiFormatReader() )
see  https://github.com/zxing-js/library/issues/371