### PR TITLE
Fix unpkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "module": "./esm/index.js",
   "typings": "./esm/index.d.ts",
   "esnext": "./es2015/index.js",
-  "unpkg": "./umd/zxing-browser.min.js",
+  "unpkg": "./umd/index.min.js",
   "scripts": {
     "lint": "yarn tslint --project .",
     "clean": "yarn shx rm -rf dist output",


### PR DESCRIPTION
`npm run build` creates `./umd/index.min.js`. Point unpkg to that one instead of `./umd/zxing-browser.min.js` which does not exist.

Fixes https://github.com/zxing-js/library/issues/449 https://github.com/zxing-js/library/issues/447 https://github.com/zxing-js/library/issues/445