### PR TITLE
Added guard for when raw bytes aren't set

### DIFF
--- a/src/core/oned/MultiFormatUPCEANReader.ts
+++ b/src/core/oned/MultiFormatUPCEANReader.ts
@@ -100,7 +100,7 @@ export default class MultiFormatUPCEANReader extends OneDReader {
           const resultUPCA: Result = new Result(
             result.getText().substring(1),
             rawBytes,
-            rawBytes.length,
+            rawBytes === null ? 0 : rawBytes.length,
             result.getResultPoints(),
             BarcodeFormat.UPC_A
           );


### PR DESCRIPTION
`UPCEANReader` supplies null and 0 for rawBytes and length respectively (see [src/core/oned/UPCEANReader.ts line 103](https://github.com/zxing-js/library/blob/b88907ccc4cfb3f8dec80650afdc8c8f99d771f9/src/core/oned/UPCEANReader.ts#L103)). If EAN13 and UPC_A are both enabled and the barcode starts with a 0, then line 103 of the conversion here threw an exception at `rawBytes.length` which was caught and converted into `NotFoundException` higher up.