### PR TITLE
ZXING: Fix yarn test error

### DIFF
--- a/src/test/core/util/AssertUtils.ts
+++ b/src/test/core/util/AssertUtils.ts
@@ -20,7 +20,7 @@ export default class AssertUtils {
 }
 
 
-export const assertEquals = assert.strictEqual;
+export const assertEquals = <T>(actual: any, expected: T, message?: string) => assert.strictEqual(actual, expected, message);
 export const assertArrayEquals = (a: Array<any> | Uint8Array | Int32Array, b: Array<any> | Uint8Array | Int32Array) => assert.deepStrictEqual(a, b);
 export const assertFalse = x => assert.strictEqual(!!x, false);
 export const assertTrue = x => assert.strictEqual(!!x, true);


### PR DESCRIPTION
  + Fixed AssertUtils assertEquals needs an explicit type annotation error
  + Allows further forks to run the existing tests