### PR TITLE
Fix for UPC-A codes being read as EAN13 with a leading zero

### DIFF
--- a/src/core/oned/MultiFormatUPCEANReader.ts
+++ b/src/core/oned/MultiFormatUPCEANReader.ts
@@ -100,7 +100,7 @@ export default class MultiFormatUPCEANReader extends OneDReader {
           const resultUPCA: Result = new Result(
             result.getText().substring(1),
             rawBytes,
-            rawBytes.length,
+            (rawBytes ? rawBytes.length : null),
             result.getResultPoints(),
             BarcodeFormat.UPC_A
           );


### PR DESCRIPTION
Fix for #88.

Zxing will use EAN13 Reader to decode UPC-A if both are enabled, but EAN13 is 13 digits and UPC-A is 12. Inside MultiFormatUPCEANReader, if a UPC-A code is detected, it removes the first char with result.getText().substring(1).

The problem here is that for EAN13, 'result' is created with rawBytes as a null value, and rawBytes.length gave an exception when accessed.