### PR TITLE
Fix for feature/multi qr code reader

### DIFF
--- a/src/test/core/oned/rss/expanded/BinaryUtil.ts
+++ b/src/test/core/oned/rss/expanded/BinaryUtil.ts
@@ -1,7 +1,5 @@
-import StringBuilder from '../../../../../core/util/StringBuilder';
 import { BitArray, IllegalStateException } from '@zxing/library';
-import StringBuilder from 'src/core/util/StringBuilder';
-
+import StringBuilder from '../../../../../core/util/StringBuilder';
 
 /*
  * Copyright (C) 2010 ZXing authors

--- a/src/test/core/util/AssertUtils.ts
+++ b/src/test/core/util/AssertUtils.ts
@@ -1,3 +1,4 @@
+/** @type {any} */
 import * as assert from 'assert';
 
 export default class AssertUtils {
@@ -20,7 +21,7 @@ export default class AssertUtils {
 }
 
 
-export const assertEquals = assert.strictEqual;
+export const assertEquals: any = assert.strictEqual;
 export const assertArrayEquals = (a: Array<any> | Uint8Array | Int32Array, b: Array<any> | Uint8Array | Int32Array) => assert.deepStrictEqual(a, b);
 export const assertFalse = x => assert.strictEqual(!!x, false);
 export const assertTrue = x => assert.strictEqual(!!x, true);

--- a/src/test/core/util/AssertUtils.ts
+++ b/src/test/core/util/AssertUtils.ts
@@ -1,4 +1,3 @@
-/** @type {any} */
 import * as assert from 'assert';
 
 export default class AssertUtils {


### PR DESCRIPTION
Fixed the following to allow tests to run

- Removed duplicate import (and shifted it's position to prevent merge conflict with master later)
- Explicitly specify assert function return value, to prevent typescript errors:
```sh
src/test/core/pdf417/decoder/PDF417Decoder.spec.ts:131:5 - error TS2775: Assertions require every name in the call target to be declared with an explicit type annotation.

131     assertEquals(260013, resultMetadata.getChecksum());
        ~~~~~~~~~~~~

  src/test/core/util/AssertUtils.ts:23:14
    23 export const assertEquals = assert.strictEqual;
                    ~~~~~~~~~~~~
    'assertEquals' needs an explicit type annotation.
```