### PR TITLE
Fix UPC-A decoding

### DIFF
--- a/src/core/oned/MultiFormatUPCEANReader.ts
+++ b/src/core/oned/MultiFormatUPCEANReader.ts
@@ -46,7 +46,9 @@ export default class MultiFormatUPCEANReader extends OneDReader {
 
       if (possibleFormats.indexOf(BarcodeFormat.EAN_13) > -1) {
         readers.push(new EAN13Reader());
-      } else if (possibleFormats.indexOf(BarcodeFormat.UPC_A) > -1) {
+      }
+
+      if (possibleFormats.indexOf(BarcodeFormat.UPC_A) > -1) {
         readers.push(new UPCAReader());
       }
 
@@ -61,7 +63,7 @@ export default class MultiFormatUPCEANReader extends OneDReader {
 
     if (readers.length === 0) {
       readers.push(new EAN13Reader());
-      // UPC-A is covered by EAN-13
+      readers.push(new UPCAReader());
       readers.push(new EAN8Reader());
       readers.push(new UPCEReader());
     }


### PR DESCRIPTION
As laid out by @besworks in https://github.com/zxing-js/browser/issues/39#issuecomment-825213883, this fixes the UPC-A decoding if the `BrowserMultiFormatOneDReader` is being used.