### PR TITLE
fix: broken demo links

### DIFF
--- a/docs/examples/aztec-camera/index.html
+++ b/docs/examples/aztec-camera/index.html
@@ -61,7 +61,7 @@
 
   </main>
 
-  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
   <script type="text/javascript">
     window.addEventListener('load', function () {
       let selectedDeviceId;

--- a/docs/examples/barcode-camera/index.html
+++ b/docs/examples/barcode-camera/index.html
@@ -60,7 +60,7 @@
 
     </main>
 
-    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
     <script type="text/javascript">
         window.addEventListener('load', function () {
             let selectedDeviceId;

--- a/docs/examples/barcode-image/index.html
+++ b/docs/examples/barcode-image/index.html
@@ -100,7 +100,7 @@
 
   </main>
 
-  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
   <script type="text/javascript">
     window.addEventListener('load', () => {
 

--- a/docs/examples/datamatrix-image/index.html
+++ b/docs/examples/datamatrix-image/index.html
@@ -88,7 +88,7 @@
 
   </main>
 
-  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
   <script type="text/javascript">
     window.addEventListener('load', function () {
       const codeReader = new ZXing.BrowserDatamatrixCodeReader()

--- a/docs/examples/multi-image/index.html
+++ b/docs/examples/multi-image/index.html
@@ -55,7 +55,7 @@
 
     </main>
 
-    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
     <script type="text/javascript">
         window.addEventListener('load', function () {
             const codeReader = new ZXing.BrowserMultiFormatReader()

--- a/docs/examples/pdf417-image/index.html
+++ b/docs/examples/pdf417-image/index.html
@@ -90,7 +90,7 @@
 
   </main>
 
-  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
   <script type="text/javascript">
     window.addEventListener('load', function () {
       const codeReader = new ZXing.BrowserPDF417Reader()

--- a/docs/examples/qr-camera/index.html
+++ b/docs/examples/qr-camera/index.html
@@ -67,7 +67,7 @@
 
   </main>
 
-  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
   <script type="text/javascript">
     function decodeOnce(codeReader, selectedDeviceId) {
       codeReader.decodeFromInputVideoDevice(selectedDeviceId, 'video').then((result) => {

--- a/docs/examples/qr-image/index.html
+++ b/docs/examples/qr-image/index.html
@@ -55,7 +55,7 @@
 
     </main>
 
-    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
     <script type="text/javascript">
         window.addEventListener('load', function () {
             const codeReader = new ZXing.BrowserQRCodeReader()

--- a/docs/examples/qr-svg-writer/index.html
+++ b/docs/examples/qr-svg-writer/index.html
@@ -53,7 +53,7 @@
 
     </main>
 
-    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+    <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
     <script type="text/javascript" src="https://unpkg.com/file-saver@latest"></script>
     <script type="text/javascript">
         window.addEventListener('load', () => {

--- a/docs/examples/qr-video/index.html
+++ b/docs/examples/qr-video/index.html
@@ -62,7 +62,7 @@
 
   </main>
 
-  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest"></script>
+  <script type="text/javascript" src="https://unpkg.com/@zxing/library@latest/umd/index.min.js"></script>
   <script type="text/javascript">
     window.addEventListener('load', function () {
       const codeReader = new ZXing.BrowserQRCodeReader()


### PR DESCRIPTION
This PR is fixing the issue with invalid links on demo pages.

Old link `https://unpkg.com/@zxing/library@latest` returns HTTP 404.
Updated all the links to the: `https://unpkg.com/@zxing/library@latest/umd/index.min.js`

Strangely enough 1 example file `multi-camera` already had updated link but all other demo pages did not.
Tested it locally using `npx serve` I was able to run all the examples.