### PR TITLE
Update MultiFormatReader example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,12 +94,10 @@ hints.set(DecodeHintType.POSSIBLE_FORMATS, formats);
 
 const reader = new MultiFormatReader();
 
-reader.setHints(hints);
-
 const luminanceSource = new RGBLuminanceSource(imgByteArray, imgWidth, imgHeight);
 const binaryBitmap = new BinaryBitmap(new HybridBinarizer(luminanceSource));
 
-reader.decode(binaryBitmap);
+reader.decode(binaryBitmap, hints);
 ```
 
 ## Contributing


### PR DESCRIPTION
If we call `decode` of MultiFormatReader without hints argument, this.hints seems overrided with undefined.

https://github.com/zxing-js/library/blob/89c4c2350f30ac844daa7400743b9a14b3f692a8/src/core/MultiFormatReader.ts#L72-L75
https://github.com/zxing-js/library/blob/89c4c2350f30ac844daa7400743b9a14b3f692a8/src/core/MultiFormatReader.ts#L101-L102