### PR TITLE
Update non-UMD build configs to not include source map files

### DIFF
--- a/tsconfig.lib-cjs.json
+++ b/tsconfig.lib-cjs.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
-    "outDir": "dist/cjs"
+    "outDir": "dist/cjs",
+    "sourceMap": false
   },
   "exclude": [
     "src/test"

--- a/tsconfig.lib-es2015.json
+++ b/tsconfig.lib-es2015.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "es2015",
     "target": "es2015",
-    "outDir": "dist/es2015"
+    "outDir": "dist/es2015",
+    "sourceMap": false
   },
   "exclude": [
     "src/test"

--- a/tsconfig.lib-esm.json
+++ b/tsconfig.lib-esm.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "es2015",
     "target": "es5",
-    "outDir": "dist/esm"
+    "outDir": "dist/esm",
+    "sourceMap": false
   },
   "exclude": [
     "src/test"

--- a/tsconfig.lib-esnext.json
+++ b/tsconfig.lib-esnext.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "module": "esnext",
     "target": "esnext",
-    "outDir": "dist/esnext"
+    "outDir": "dist/esnext",
+    "sourceMap": false
   },
   "exclude": [
     "src/test"


### PR DESCRIPTION
Many issues have cropped up since Create-react-app 5's release regarding console warnings about source maps.  Ultimately, the issue comes down to not including the src directory with the npm bundle.  While doing so would clean up the issues, that leads to problems where a developer trying to debug their own use of this library may make source changes without updating their build files, leading to more frustration.  Other proposed solutions also have their own issues:

- https://github.com/zxing-js/library/issues/512#issuecomment-1064751175 suggests `GENERATE_SOURCEMAP=false`, which disables sourcemaps for everything within a project.  This is absolutely overkill for a single package and should be seen as a last resort, not a solution.
- https://github.com/SAP/ui5-webcomponents/issues/5648 In many cases, this SAP issue has been mentioned suggesting that the current accepted solution is to simply use the UMD version of the build output.  While this can work, this basically kicks the proverbial can down the road in that not all projects are able to/willing to use UMD modules without additional time and effort.

This PR adds lines to each individual build config file to prevent the generation of the source map files.  By doing so, source map generation should stay enabled for development (such as it is), while any new builds should avoid the assault of console warnings. 