### PR TITLE
Update ts-custom-error to v3.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "tslint": "./node_modules/.bin/tslint \"./src/**/*.ts\""
   },
   "dependencies": {
-    "ts-custom-error": "^3.0.0"
+    "ts-custom-error": "^3.2.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^7.1.3",


### PR DESCRIPTION
ts-custom-error sometimes fails with latest typescript. See https://github.com/adriengibrat/ts-custom-error/issues/116 for details, version 3.2.1 is supposed to fix that issue, and it also works with semver ^3.0.0