### PR TITLE
Fixed "Write QR Code to SVG" example failed to save the file

### DIFF
--- a/docs/examples/qr-svg-writer/index.html
+++ b/docs/examples/qr-svg-writer/index.html
@@ -71,7 +71,7 @@
             })
 
             document.getElementById('saveButton').addEventListener('click', () => {
-                const svgData = (new XMLSerializer()).serializeToString(svgElement)
+                const svgData = (new XMLSerializer()).serializeToString(document.getElementById('result'))
                 const blob = new Blob([svgData])
                 saveAs(blob, 'zxing-qrcode-example.svg')
             })


### PR DESCRIPTION
QRCode could not be saved to file, so I fixed it for my own use and now share it back.