### PR TITLE
added code39 extended mode decode hint

### DIFF
--- a/src/core/DecodeHintType.ts
+++ b/src/core/DecodeHintType.ts
@@ -67,6 +67,12 @@ enum DecodeHintType {
     ASSUME_CODE_39_CHECK_DIGIT/*(Void.class)*/,
 
     /**
+     * Enable extended mode for Code 39 codes. Doesn't matter what it maps to;
+     * use {@link Boolean#TRUE}.
+     */
+    ENABLE_CODE_39_EXTENDED_MODE/*(Void.class)*/,
+
+    /**
      * Assume the barcode is being processed as a GS1 barcode, and modify behavior as needed.
      * For example this affects FNC1 handling for Code 128 (aka GS1-128). Doesn't matter what it maps to;
      * use {@link Boolean#TRUE}.

--- a/src/core/oned/MultiFormatOneDReader.ts
+++ b/src/core/oned/MultiFormatOneDReader.ts
@@ -43,6 +43,7 @@ export default class MultiFormatOneDReader extends OneDReader {
     super();
     const possibleFormats = !hints ? null : <BarcodeFormat[]>hints.get(DecodeHintType.POSSIBLE_FORMATS);
     const useCode39CheckDigit = hints && hints.get(DecodeHintType.ASSUME_CODE_39_CHECK_DIGIT) !== undefined;
+    const useCode39ExtendedMode = hints && hints.get(DecodeHintType.ENABLE_CODE_39_EXTENDED_MODE) !== undefined;
 
     if (possibleFormats) {
       if (possibleFormats.includes(BarcodeFormat.EAN_13) ||
@@ -52,7 +53,7 @@ export default class MultiFormatOneDReader extends OneDReader {
         this.readers.push(new MultiFormatUPCEANReader(hints));
       }
       if (possibleFormats.includes(BarcodeFormat.CODE_39)) {
-        this.readers.push(new Code39Reader(useCode39CheckDigit));
+        this.readers.push(new Code39Reader(useCode39CheckDigit, useCode39ExtendedMode));
       }
       if (possibleFormats.includes(BarcodeFormat.CODE_93)) {
           this.readers.push(new Code93Reader());


### PR DESCRIPTION
The `Code39Reader` has an `extendedMode` Option. With my enhancement you can now enable the `extendedMode` like other features via decode hints.

Example:
```javascript
const hints = new Map();

hints.set(DecodeHintType.POSSIBLE_FORMATS, [BarcodeFormat.CODE_39]);
hints.set(DecodeHintType.ENABLE_CODE_39_EXTENDED_MODE, true);

const codeReader = new BrowserMultiFormatReader(hints);
```