### PR TITLE
Fix mirrored QR code reading due to BitMatrixParser.remask() always failing

### DIFF
--- a/src/core/qrcode/decoder/BitMatrixParser.ts
+++ b/src/core/qrcode/decoder/BitMatrixParser.ts
@@ -214,7 +214,7 @@ export default class BitMatrixParser {
         if (this.parsedFormatInfo === null) {
             return; // We have no format information, and have no data mask
         }
-        const dataMask = DataMask.values[this.parsedFormatInfo.getDataMask()];
+        const dataMask = DataMask.values.get(this.parsedFormatInfo.getDataMask());
         const dimension = this.bitMatrix.getHeight();
         dataMask.unmaskBitMatrix(this.bitMatrix, dimension);
     }


### PR DESCRIPTION
`DataMask.values` is a `Map`, and accessing it with `[]` yields undefined, causing `remask()` to always fail at line 219. This causes mirrored QR codes to be unreadable.

Fixes https://github.com/zxing-js/library/issues/604

I didn't spot a changelog or anything so I guess this change is all that's needed?