### PR TITLE
#607 Wrong characters for Aztec decoder in `Decoder.MIXED_TABLE`

### DIFF
--- a/src/core/aztec/decoder/Decoder.ts
+++ b/src/core/aztec/decoder/Decoder.ts
@@ -56,8 +56,6 @@ export default class Decoder {
     ];
 
     private static MIXED_TABLE: string[] = [
-        // Module parse failed: Octal literal in strict mode (50:29)
-        // so number string were scaped
         'CTRL_PS', ' ', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07', '\b', '\t', '\n',
         '\x0b', '\f', '\r', '\x1b', '\x1c', '\x1d', '\x1e', '\x1f', '@', '\\', '^', '_',
         '`', '|', '~', '\x7f', 'CTRL_LL', 'CTRL_UL', 'CTRL_PL', 'CTRL_BS'

--- a/src/core/aztec/decoder/Decoder.ts
+++ b/src/core/aztec/decoder/Decoder.ts
@@ -58,9 +58,9 @@ export default class Decoder {
     private static MIXED_TABLE: string[] = [
         // Module parse failed: Octal literal in strict mode (50:29)
         // so number string were scaped
-        'CTRL_PS', ' ', '\\1', '\\2', '\\3', '\\4', '\\5', '\\6', '\\7', '\b', '\t', '\n',
-        '\\13', '\f', '\r', '\\33', '\\34', '\\35', '\\36', '\\37', '@', '\\', '^', '_',
-        '`', '|', '~', '\\177', 'CTRL_LL', 'CTRL_UL', 'CTRL_PL', 'CTRL_BS'
+        'CTRL_PS', ' ', '\x01', '\x02', '\x03', '\x04', '\x05', '\x06', '\x07', '\b', '\t', '\n',
+        '\x0b', '\f', '\r', '\x1b', '\x1c', '\x1d', '\x1e', '\x1f', '@', '\\', '^', '_',
+        '`', '|', '~', '\x7f', 'CTRL_LL', 'CTRL_UL', 'CTRL_PL', 'CTRL_BS'
     ];
 
     private static PUNCT_TABLE: string[] = [

--- a/src/test/core/aztec/decoder/Decoder.spec.ts
+++ b/src/test/core/aztec/decoder/Decoder.spec.ts
@@ -158,6 +158,38 @@ describe('DecoderTest', () => {
     /**
      * @Test
      */
+    it('testDecodeSpecialCharacters', () => {
+        const matrix = BitMatrix.parseFromString(
+            'X X . . . X X . X X . X . . . . . . X \n' +
+            'X . . X X . X . . X . . . X . X X X . \n' +
+            'X . X . X X X X . . . X . . . . X . X \n' +
+            '. . . X X . X . . . . X . X X . X . X \n' +
+            'X . X . X X . X . . X X . . X . . . . \n' +
+            '. . . X X X X X X X X X X X X X . X X \n' +
+            '. X X X . X . . . . . . . X . X X . X \n' +
+            'X . X . X X . X X X X X . X X . . . . \n' +
+            '. X . X X X . X . . . X . X X . . X . \n' +
+            '. . . . . X . X . X . X . X . . . . X \n' +
+            '. . . X . X . X . . . X . X . . X X . \n' +
+            'X . . . . X . X X X X X . X . X X X . \n' +
+            'X . X . . X . . . . . . . X . X X . . \n' +
+            '. X X . . X X X X X X X X X X X . . . \n' +
+            'X . X . . . X X X X X . . . . X . X X \n' +
+            '. . . X X X . . . X X X . X X . X X X \n' +
+            'X X X . X X X X . X . X X . X X X X . \n' +
+            '. . . X . . X X . . X . X . X X . X X \n' +
+            'X X . . X . X X X . . . . X . . . X X \n',
+            'X ', '. ');
+        const r = new AztecDetectorResult(matrix, NO_POINTS, true, 14, 2);
+        const result = new AztecDecoder().decode(r);
+        assertEquals(
+            '\x01\x02\x03\x04\x05\x06\x07\x0b\x1b\x1c\x1d\x1e\x1f\x7f',
+            result.getText());
+  });
+
+    /**
+     * @Test
+     */
     it('testRawBytes', () => {
         let bool0: boolean[] = [];
         let bool1: boolean[] = [true];


### PR DESCRIPTION
As described in #607 decoding Aztec codes in some cases gives wrong results, i.e., `'\x01'` / `'\x02'` / `'\x03'` / `'\x04'` / `'\x05'` / `'\x06'` / `'\x07'` / `'\x0b'` / `'\x1b'` / `'\x1c'` / `'\x1d'` / `'\x1e'` / `'\x1f'` / `'\x7f'` get decoded to `'\\1'` / `'\\2'` / `'\\3'` / `'\\4'` / `'\\5'` / `'\\6'` / `'\\7'` / `'\\13'` / `'\\33'` / `'\\34'` / `'\\35'` / `'\\36'` / `'\\37'` / `'\\177'`.

By applying this pull request the above mentioned characters should get correctly decoded.

The current array entries were probably adopted from the Java version of this library, where one may specify characters by their octal code points using a `"\[0-9]"` notation. Thus, e.g., `"\13"` in Java equals, e.g., `String.fromCharCode(0o13)` or `'\x0b'` in JavaScript.

Thanks a lot for reviewing and maybe merging this pull request.