### PR TITLE
Fix readers not reset by Browser*Readers, causing invalid results

### DIFF
--- a/src/browser/BrowserCodeReader.ts
+++ b/src/browser/BrowserCodeReader.ts
@@ -1046,7 +1046,12 @@ export class BrowserCodeReader {
    * Call the encapsulated readers decode
    */
   public decodeBitmap(binaryBitmap: BinaryBitmap): Result {
-    return this.reader.decode(binaryBitmap, this._hints);
+    try {
+      return this.reader.decode(binaryBitmap, this._hints);
+    } finally {
+      // Readers need to be reset before being reused on another bitmap.
+      this.reader.reset();
+    }
   }
 
   /**

--- a/src/browser/BrowserMultiFormatReader.ts
+++ b/src/browser/BrowserMultiFormatReader.ts
@@ -22,6 +22,11 @@ export class BrowserMultiFormatReader extends BrowserCodeReader {
    * attention to the hints set in the constructor function
    */
   public decodeBitmap(binaryBitmap: BinaryBitmap): Result {
-    return this.reader.decodeWithState(binaryBitmap);
+    try {
+      return this.reader.decodeWithState(binaryBitmap);
+    } finally {
+      // Readers need to be reset before being reused on another bitmap.
+      this.reader.reset();
+    }
   }
 }


### PR DESCRIPTION
As seen in the original ZXing Java library, Readers are meant to be reset after every use:

https://github.com/zxing/zxing/blob/2dfb2054af1e1872ac5354e6d8218931fb88e021/android/src/com/google/zxing/client/android/DecodeHandler.java#L76-L83

Not doing so results in them retaining state between decode attempts. In practice, this results in data from old images being used for later decode attempts of other images, and stale results being returned forever.

Fixes #612