### PR TITLE
Fix BrowserMultiFormatReader doesn't forward hints to internal reader

### DIFF
--- a/src/browser/BrowserMultiFormatReader.ts
+++ b/src/browser/BrowserMultiFormatReader.ts
@@ -8,6 +8,13 @@ export class BrowserMultiFormatReader extends BrowserCodeReader {
 
   protected readonly reader: MultiFormatReader;
 
+  set hints(hints: Map<DecodeHintType, any>) {
+    this._hints = hints || null;
+
+    // Since we don't pass the hints in `decodeBitmap` as other Browser readers do, we need to set them here.
+    this.reader.setHints(hints);
+  }
+
   public constructor(
     hints: Map<DecodeHintType, any> = null,
     timeBetweenScansMillis: number = 500


### PR DESCRIPTION
This made changing hints through the `BrowserMultiFormatReader` impossible, as the underlying `MultiFormatReader` never receives the new hints.

Fixes #534