### PR TITLE
CI: Configure yarn cache path using GITHUB_OUTPUT ENV variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir='$(yarn cache dir)'" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)


### PR DESCRIPTION
This PR avoids a GitHub Actions deprecation warning.

(The build is red due to an E2E test failure, which was the state also before this change. This PR does not address that.)

The old syntax was deprecated a while ago.
https://github.blog/changelog/2022-10-10-github-actions-deprecating-save-state-and-set-output-commands/